### PR TITLE
Add compile check for analyze script

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -1,4 +1,3 @@
-\
 import json, statistics, pathlib, datetime
 from collections import Counter
 

--- a/workflow-cookbook/tests/test_analyze_script.py
+++ b/workflow-cookbook/tests/test_analyze_script.py
@@ -1,0 +1,8 @@
+import py_compile
+from pathlib import Path
+
+
+def test_analyze_script_is_syntax_valid():
+    repo_root = Path(__file__).resolve().parents[2]
+    script_path = repo_root / "scripts" / "analyze.py"
+    py_compile.compile(str(script_path), doraise=True)


### PR DESCRIPTION
## Summary
- add a regression test that compiles `scripts/analyze.py` to ensure syntax validity
- remove the stray leading backslash so the analyze script starts with its import statements

## Testing
- pytest workflow-cookbook/tests/test_analyze_script.py

------
https://chatgpt.com/codex/tasks/task_e_68ee24d4cf4c8321bbce92c932a9147c