### PR TITLE
Fix CODEOWNERS gate workflow

### DIFF
--- a/.github/workflows/pr_gate.yml
+++ b/.github/workflows/pr_gate.yml
@@ -10,10 +10,31 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Require CODEOWNERS approval
-        uses: mheap/github-action-required-reviewers@v2
+        uses: actions/github-script@v7
         with:
-          reviewers: 'CODEOWNERS'
-          failOnMissing: true
+          script: |
+            const {owner, repo} = context.repo;
+            const pull_number = context.payload.pull_request.number;
+            const {data: pr} = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number,
+            });
+
+            const pendingUsers = pr.requested_reviewers?.map((reviewer) => `@${reviewer.login}`) ?? [];
+            const pendingTeams = pr.requested_teams?.map(
+              (team) => `@${team.organization.login}/${team.slug}`,
+            ) ?? [];
+
+            if (pendingUsers.length === 0 && pendingTeams.length === 0) {
+              core.notice('All required reviewers have approved.');
+              return;
+            }
+
+            const pending = [...pendingUsers, ...pendingTeams];
+            core.setFailed(
+              `Awaiting required review from: ${pending.join(', ')}`,
+            );
       - name: Block auto-merge (informational)
         run: |
           echo "Auto merge is disabled by policy"


### PR DESCRIPTION
## Summary
- replace the unavailable mheap/github-action-required-reviewers action with an inline github-script check for pending CODEOWNERS reviews

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68ee267f1f7883219a2500790915c51d