### PR TITLE
Add syntax check test for analyze script

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -1,9 +1,14 @@
-import json, statistics, pathlib, datetime
+import datetime
+import json
+import pathlib
+import statistics
 from collections import Counter
+
 
 LOG = pathlib.Path("logs/test.jsonl")
 REPORT = pathlib.Path("reports/today.md")
 ISSUE_OUT = pathlib.Path("reports/issue_suggestions.md")
+
 
 def load_results():
     tests, durs, fails = [], [], []
@@ -21,6 +26,7 @@ def load_results():
                 fails.append(obj.get("name", "unknown"))
     return tests, durs, fails
 
+
 def p95(values):
     if not values:
         return 0
@@ -29,8 +35,9 @@ def p95(values):
         return int(statistics.quantiles(values, n=20)[18])
     except Exception:
         values_sorted = sorted(values)
-        idx = int(0.95 * (len(values_sorted)-1))
+        idx = int(0.95 * (len(values_sorted) - 1))
         return int(values_sorted[idx])
+
 
 def main():
     tests, durs, fails = load_results()
@@ -49,7 +56,9 @@ def main():
         if fails:
             f.write("## Why-Why (draft)\n")
             for name, cnt in Counter(fails).items():
-                f.write(f"- {name}: 仮説=前処理の不安定/依存の競合/境界値不足\n")
+                f.write(
+                    f"- {name}: 仮説=前処理の不安定/依存の競合/境界値不足\n"
+                )
 
     # Issue候補のメモ（Actionsで拾ってIssue化）
     if fails:
@@ -57,6 +66,7 @@ def main():
             f.write("### 反省TODO\n")
             for name in sorted(set(fails)):
                 f.write(f"- [ ] {name} の再現手順/前提/境界値を追加\n")
+
 
 if __name__ == "__main__":
     main()

--- a/workflow-cookbook/tests/test_analyze_script.py
+++ b/workflow-cookbook/tests/test_analyze_script.py
@@ -1,8 +1,6 @@
-import py_compile
 from pathlib import Path
+import py_compile
 
 
-def test_analyze_script_is_syntax_valid():
-    repo_root = Path(__file__).resolve().parents[2]
-    script_path = repo_root / "scripts" / "analyze.py"
-    py_compile.compile(str(script_path), doraise=True)
+def test_analyze_script_compiles() -> None:
+    py_compile.compile(Path("scripts/analyze.py"), doraise=True)


### PR DESCRIPTION
## Summary
- add a unit test that compiles scripts/analyze.py via py_compile to guard against syntax errors
- tidy analyze.py imports so the module begins with import statements and update minor formatting

## Testing
- pytest workflow-cookbook/tests/test_analyze_script.py

------
https://chatgpt.com/codex/tasks/task_e_68ee26af243483219ae777c890ee8f46