### PR TITLE
Fix analyze.py p95 fallback rounding

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -1,4 +1,5 @@
 import json, statistics, pathlib, datetime
+import math
 import statistics
 from collections import Counter
 
@@ -33,7 +34,10 @@ def p95(values):
         return int(statistics.quantiles(values, n=20)[18])
     except Exception:
         values_sorted = sorted(values)
-        idx = int(0.95 * (len(values_sorted) - 1))
+        if not values_sorted:
+            return 0
+        idx = math.ceil(0.95 * (len(values_sorted) - 1))
+        idx = min(idx, len(values_sorted) - 1)
         return int(values_sorted[idx])
 
 

--- a/workflow-cookbook/tests/test_analyze_script.py
+++ b/workflow-cookbook/tests/test_analyze_script.py
@@ -1,7 +1,25 @@
 from __future__ import annotations
 
-from pathlib import Path
+import importlib.util
 import py_compile
+import statistics
+from pathlib import Path
+
+
+def test_p95_fallback_rounds_up(monkeypatch) -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    script_path = repo_root / "scripts" / "analyze.py"
+    spec = importlib.util.spec_from_file_location("_analyze_test_module", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    def _raise_stats_error(*_: object, **__: object) -> list[float]:
+        raise statistics.StatisticsError("boom")
+
+    monkeypatch.setattr(module.statistics, "quantiles", _raise_stats_error)
+
+    assert module.p95([10, 20]) == 20
 
 
 def test_analyze_script_compiles(tmp_path: Path) -> None:
@@ -15,17 +33,3 @@ def test_analyze_script_compiles(tmp_path: Path) -> None:
     )
 
     assert Path(compiled_path) == cfile
-import py_compile
-from pathlib import Path
-
-
-def test_analyze_script_compiles() -> None:
-    repo_root = Path(__file__).resolve().parents[2]
-    script_path = repo_root / "scripts" / "analyze.py"
-    py_compile.compile(str(script_path), doraise=True)
-from pathlib import Path
-import py_compile
-
-
-def test_analyze_script_compiles() -> None:
-    py_compile.compile(Path("scripts/analyze.py"), doraise=True)


### PR DESCRIPTION
## Summary
- add a regression test that exercises analyze.p95 when statistics.quantiles fails
- adjust the p95 fallback to round the percentile index up so small samples return the max value

## Testing
- pytest workflow-cookbook/tests/test_analyze_script.py

------
https://chatgpt.com/codex/tasks/task_e_68ee2a62d4288321b2f453409a8afbe2