### PR TITLE
Handle null durations in analyze script

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -21,13 +21,8 @@ def load_results():
                 continue
             obj = json.loads(line)
             tests.append(obj.get("name", "unknown"))
-            raw_duration = obj.get("duration_ms", 0)
-            try:
-                if raw_duration is None:
-                    raise TypeError
-                duration = int(raw_duration)
-            except (TypeError, ValueError):
-                duration = 0
+            raw_duration = obj.get("duration_ms")
+            duration = int(raw_duration) if isinstance(raw_duration, (int, float)) else 0
             durs.append(duration)
             if obj.get("status") == "fail":
                 fails.append(obj.get("name", "unknown"))


### PR DESCRIPTION
## Summary
- normalize non-numeric duration_ms values to zero in `scripts/analyze.py`
- extend `workflow-cookbook/tests/test_analyze_script.py` to cover null durations and ensure percentile computation succeeds

## Testing
- pytest workflow-cookbook/tests/test_analyze_script.py

------
https://chatgpt.com/codex/tasks/task_e_68ee490af01083219f59052ae12ace4b