### PR TITLE
Handle zero-test case in analyze report

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -44,8 +44,11 @@ def p95(values):
 
 def main():
     tests, durs, fails = load_results()
-    total = len(tests) or 1
-    pass_rate = (total - len(fails)) / total
+    total = len(tests)
+    if total == 0:
+        pass_rate = 0.0
+    else:
+        pass_rate = (total - len(fails)) / total
     dur_p95 = p95(durs)
     now = datetime.datetime.utcnow().isoformat()
 

--- a/workflow-cookbook/tests/test_analyze_script.py
+++ b/workflow-cookbook/tests/test_analyze_script.py
@@ -78,3 +78,20 @@ def test_load_results_sanitizes_non_numeric_durations(
 
     p95_value = analyze.p95(durs)
     assert isinstance(p95_value, int)
+
+
+def test_main_reports_zero_when_no_log(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    analyze = load_analyze_module()
+
+    report_path = tmp_path / "reports" / "today.md"
+    monkeypatch.setattr(analyze, "LOG", tmp_path / "missing.jsonl")
+    monkeypatch.setattr(analyze, "REPORT", report_path)
+
+    analyze.main()
+
+    contents = report_path.read_text(encoding="utf-8")
+
+    assert "Total tests: 0" in contents
+    assert "Pass rate:" in contents and "100.00%" not in contents


### PR DESCRIPTION
## Summary
- add coverage ensuring analyze.main reports zero totals when no log file exists
- adjust analyze.main to keep totals at zero and report a 0% pass rate in the empty-log scenario

## Testing
- pytest workflow-cookbook/tests/test_analyze_script.py

------
https://chatgpt.com/codex/tasks/task_e_68ee4fdfb1f88321a3ba1e14da31ccc7