### PR TITLE
Add test coverage for empty analyze log pass rate

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -46,7 +46,7 @@ def main():
     tests, durs, fails = load_results()
     total = len(tests)
     if total == 0:
-        pass_rate = 0.0
+        pass_rate: float = 0.0
     else:
         pass_rate = (total - len(fails)) / total
     dur_p95 = p95(durs)

--- a/workflow-cookbook/tests/test_analyze_script.py
+++ b/workflow-cookbook/tests/test_analyze_script.py
@@ -95,3 +95,24 @@ def test_main_reports_zero_when_no_log(
 
     assert "Total tests: 0" in contents
     assert "Pass rate:" in contents and "100.00%" not in contents
+
+
+def test_main_reports_zero_when_log_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    analyze = load_analyze_module()
+
+    log_path = tmp_path / "logs" / "empty.jsonl"
+    log_path.parent.mkdir(parents=True)
+    log_path.write_text("", encoding="utf-8")
+
+    report_path = tmp_path / "reports" / "today.md"
+    monkeypatch.setattr(analyze, "LOG", log_path)
+    monkeypatch.setattr(analyze, "REPORT", report_path)
+
+    analyze.main()
+
+    contents = report_path.read_text(encoding="utf-8")
+
+    assert "Total tests: 0" in contents
+    assert "Pass rate: 0.00%" in contents


### PR DESCRIPTION
## Summary
- add regression coverage ensuring analyze.main reports zero totals when the log file exists but is empty
- annotate pass_rate calculation for zero-test condition to keep formatting consistent with zero totals

## Testing
- pytest workflow-cookbook/tests/test_analyze_script.py

------
https://chatgpt.com/codex/tasks/task_e_68ee51f4dda883219bcc51411408be56