### PR TITLE
Ensure analyze removes issue notes when no failures occur

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -92,6 +92,8 @@ def main() -> None:
             f.write("### 反省TODO\n")
             for name in sorted(set(fails)):
                 f.write(f"- [ ] {name} の再現手順/前提/境界値を追加\n")
+    elif ISSUE_OUT.exists():
+        ISSUE_OUT.unlink()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add coverage verifying analyze clears existing issue suggestions when only successful logs are processed
- remove the stale issue suggestions file when analyze detects no failures

## Testing
- pytest workflow-cookbook/tests/test_analyze_script.py

------
https://chatgpt.com/codex/tasks/task_e_68ee741facf483219816eccd227b43c0