### PR TITLE
Handle priority validation failure in governance gate

### DIFF
--- a/workflow-cookbook/tests/test_check_governance_gate.py
+++ b/workflow-cookbook/tests/test_check_governance_gate.py
@@ -8,6 +8,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from tools.ci.check_governance_gate import (
     find_forbidden_matches,
     load_forbidden_patterns,
+    main,
     validate_priority_score,
 )
 
@@ -61,3 +62,24 @@ self_modification:
     )
 
     assert load_forbidden_patterns(policy) == ["core/schema/**", "auth/**"]
+
+
+def test_main_returns_error_when_priority_score_invalid(monkeypatch, tmp_path):
+    event_path = tmp_path / "event.json"
+    event_path.write_text(
+        """
+{
+  "pull_request": {
+    "body": "Priority Score: 5 / Example"
+  }
+}
+"""
+    )
+
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
+    monkeypatch.setattr("tools.ci.check_governance_gate.get_changed_paths", lambda _ref: [])
+    monkeypatch.setattr(
+        "tools.ci.check_governance_gate.validate_priority_score", lambda _body: False
+    )
+
+    assert main() == 1

--- a/workflow-cookbook/tools/ci/check_governance_gate.py
+++ b/workflow-cookbook/tools/ci/check_governance_gate.py
@@ -112,7 +112,9 @@ def main() -> int:
         print("GITHUB_EVENT_PATH is not set", file=sys.stderr)
         return 1
     body = read_event_body(Path(event_path_value))
-    validate_priority_score(body)
+    if not validate_priority_score(body):
+        print("Priority score validation failed", file=sys.stderr)
+        return 1
 
     return 0
 


### PR DESCRIPTION
## Summary
- ensure the governance gate exits with an error when priority validation fails
- add a regression test covering the failure scenario

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ee8cc0c97c8321a66d4f20fbf15b86