### PR TITLE
Validate governance priority score format

### DIFF
--- a/workflow-cookbook/tests/test_check_governance_gate.py
+++ b/workflow-cookbook/tests/test_check_governance_gate.py
@@ -33,18 +33,29 @@ def test_find_forbidden_matches(changed_paths, patterns, expected):
     "body",
     [
         "Priority Score: 5 / 安全性強化",
-        "Priority Score: 1 / 即応性向上",
+        "前文\nPriority Score: 1 / 即応性向上\n後文",
+    ],
+)
+def test_validate_priority_score_valid(body):
+    assert validate_priority_score(body) is True
+    assert getattr(validate_priority_score, "error", None) is None
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
         "Priority Score: 3",
         "Priority Score: / 理由",
         "Priority Score: abc / 理由",
         "Priority Score: <!-- 例: 5 / prioritization.yaml#phase1 -->",
-        "priority score: 3",
+        "priority score: 3 / something",
         "",
         None,
     ],
 )
-def test_validate_priority_score_is_now_noop(body):
-    assert validate_priority_score(body) is True
+def test_validate_priority_score_invalid(body):
+    assert validate_priority_score(body) is False
+    assert isinstance(getattr(validate_priority_score, "error", None), str)
 
 
 def test_load_forbidden_patterns(tmp_path):

--- a/workflow-cookbook/tools/ci/check_governance_gate.py
+++ b/workflow-cookbook/tools/ci/check_governance_gate.py
@@ -86,7 +86,42 @@ def read_event_body(event_path: Path) -> str | None:
 
 
 def validate_priority_score(body: str | None) -> bool:
-    return True
+    setattr(validate_priority_score, "error", None)
+    if body is None:
+        validate_priority_score.error = "PR body is missing"
+        return False
+    if not body.strip():
+        validate_priority_score.error = "Priority Score entry is missing"
+        return False
+
+    for raw_line in body.splitlines():
+        stripped_line = raw_line.strip()
+        if not stripped_line.startswith("Priority Score:"):
+            continue
+        content = stripped_line[len("Priority Score:") :].strip()
+        if not content:
+            validate_priority_score.error = "Priority Score value and reason are missing"
+            return False
+        if "/" not in content:
+            validate_priority_score.error = "Priority Score reason is missing"
+            return False
+        value_part, reason_part = (segment.strip() for segment in content.split("/", 1))
+        if not value_part:
+            validate_priority_score.error = "Priority Score value is missing"
+            return False
+        if not value_part.isdigit():
+            validate_priority_score.error = "Priority Score value must be a number"
+            return False
+        if not reason_part:
+            validate_priority_score.error = "Priority Score reason is missing"
+            return False
+        if reason_part.startswith("<!--"):
+            validate_priority_score.error = "Priority Score reason must be provided"
+            return False
+        return True
+
+    validate_priority_score.error = "Priority Score entry is missing"
+    return False
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary
- enforce strict validation for the Priority Score entry in the governance gate
- expose validation errors for callers and cover success/failure paths with tests

## Testing
- pytest tests/test_check_governance_gate.py

------
https://chatgpt.com/codex/tasks/task_e_68ee8dc9bcb48321a132e5e8381d8c57