### PR TITLE
Add priority score validation tests and parsing

### DIFF
--- a/workflow-cookbook/tests/test_check_governance_gate.py
+++ b/workflow-cookbook/tests/test_check_governance_gate.py
@@ -31,32 +31,26 @@ def test_find_forbidden_matches(changed_paths, patterns, expected):
 
 
 @pytest.mark.parametrize(
-    "body",
+    "body, expected",
     [
-        "Priority Score: 5 / 安全性強化",
-        "前文\nPriority Score: 1 / 即応性向上\n後文",
+        ("Priority Score: 5 / 安全性強化", True),
+        ("前文\nPriority Score: 1 / 即応性向上\n後文", True),
+        ("Priority Score: 3", False),
+        ("Priority Score: / 理由", False),
+        ("Priority Score: abc / 理由", False),
+        ("Priority Score: <!-- 例: 5 / prioritization.yaml#phase1 -->", False),
+        ("priority score: 3 / something", False),
+        ("", False),
+        (None, False),
     ],
 )
-def test_validate_priority_score_valid(body):
-    assert validate_priority_score(body) is True
-    assert getattr(validate_priority_score, "error", None) is None
-
-
-@pytest.mark.parametrize(
-    "body",
-    [
-        "Priority Score: 3",
-        "Priority Score: / 理由",
-        "Priority Score: abc / 理由",
-        "Priority Score: <!-- 例: 5 / prioritization.yaml#phase1 -->",
-        "priority score: 3 / something",
-        "",
-        None,
-    ],
-)
-def test_validate_priority_score_invalid(body):
-    assert validate_priority_score(body) is False
-    assert isinstance(getattr(validate_priority_score, "error", None), str)
+def test_validate_priority_score_table(body, expected):
+    assert validate_priority_score(body) is expected
+    error = getattr(validate_priority_score, "error", None)
+    if expected:
+        assert error is None
+    else:
+        assert isinstance(error, str)
 
 
 def test_load_forbidden_patterns(tmp_path):

--- a/workflow-cookbook/tools/ci/check_governance_gate.py
+++ b/workflow-cookbook/tools/ci/check_governance_gate.py
@@ -90,15 +90,18 @@ def validate_priority_score(body: str | None) -> bool:
     if body is None:
         validate_priority_score.error = "PR body is missing"
         return False
-    if not body.strip():
+
+    stripped_body = body.strip()
+    if not stripped_body:
         validate_priority_score.error = "Priority Score entry is missing"
         return False
 
-    for raw_line in body.splitlines():
-        stripped_line = raw_line.strip()
-        if not stripped_line.startswith("Priority Score:"):
+    prefix = "Priority Score:"
+    for raw_line in stripped_body.splitlines():
+        line = raw_line.strip()
+        if not line.startswith(prefix):
             continue
-        content = stripped_line[len("Priority Score:") :].strip()
+        content = line[len(prefix) :].strip()
         if not content:
             validate_priority_score.error = "Priority Score value and reason are missing"
             return False
@@ -109,8 +112,10 @@ def validate_priority_score(body: str | None) -> bool:
         if not value_part:
             validate_priority_score.error = "Priority Score value is missing"
             return False
-        if not value_part.isdigit():
-            validate_priority_score.error = "Priority Score value must be a number"
+        try:
+            float(value_part)
+        except ValueError:
+            validate_priority_score.error = "Priority Score value must be numeric"
             return False
         if not reason_part:
             validate_priority_score.error = "Priority Score reason is missing"


### PR DESCRIPTION
## Summary
- add table-driven tests covering valid and invalid priority score formats
- update priority score validator to parse numeric values and require justification text

## Testing
- pytest tests/test_check_governance_gate.py

------
https://chatgpt.com/codex/tasks/task_e_68ee8f5967cc832194ef3c773578456f