### PR TITLE
Handle bullet markers in priority score validation

### DIFF
--- a/workflow-cookbook/tests/test_check_governance_gate.py
+++ b/workflow-cookbook/tests/test_check_governance_gate.py
@@ -54,6 +54,18 @@ def test_validate_priority_score_table(body, expected):
         assert isinstance(error, str)
 
 
+@pytest.mark.parametrize(
+    "body",
+    [
+        "Priority Score: 5 / 安全性強化",
+        "- Priority Score: 5 / 例示",
+        "- [x] Priority Score: 8 / チェック済み",
+    ],
+)
+def test_validate_priority_score_valid(body):
+    assert validate_priority_score(body) is True
+
+
 def test_load_forbidden_patterns(tmp_path):
     policy = tmp_path / "policy.yaml"
     policy.write_text(

--- a/workflow-cookbook/tools/ci/check_governance_gate.py
+++ b/workflow-cookbook/tools/ci/check_governance_gate.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 from fnmatch import fnmatch
 from pathlib import Path
 from typing import Iterable, List, Sequence
+
+
+BULLET_PATTERN = re.compile(r"^[-*+]\s*(?:\[[xX ]\])?\s*")
 
 
 def load_forbidden_patterns(policy_path: Path) -> List[str]:
@@ -99,9 +103,10 @@ def validate_priority_score(body: str | None) -> bool:
     prefix = "Priority Score:"
     for raw_line in stripped_body.splitlines():
         line = raw_line.strip()
-        if not line.startswith(prefix):
+        normalized_line = BULLET_PATTERN.sub("", line, count=1)
+        if not normalized_line.startswith(prefix):
             continue
-        content = line[len(prefix) :].strip()
+        content = normalized_line[len(prefix) :].strip()
         if not content:
             validate_priority_score.error = "Priority Score value and reason are missing"
             return False


### PR DESCRIPTION
## Summary
- extend governance gate tests with bullet-pointed priority score cases
- strip leading list markers before validating the priority score field

## Testing
- pytest tests/test_check_governance_gate.py -q

------
https://chatgpt.com/codex/tasks/task_e_68ee906237bc83218601e3731737324b