### PR TITLE
Handle bullet-prefixed Priority Score lines

### DIFF
--- a/workflow-cookbook/tools/ci/check_governance_gate.py
+++ b/workflow-cookbook/tools/ci/check_governance_gate.py
@@ -94,12 +94,19 @@ def validate_priority_score(body: str | None) -> tuple[bool, str | None]:
     if not body:
         return False, "Priority Score セクションが見つかりません"
 
-    pattern = re.compile(r"^Priority Score:\s*(?P<content>.+)$", re.MULTILINE)
-    match = pattern.search(body)
-    if not match:
+    pattern = re.compile(r"^Priority Score:\s*(?P<content>.+)$")
+    match_content: str | None = None
+    for raw_line in body.splitlines():
+        normalized_line = BULLET_PATTERN.sub("", raw_line.lstrip(), count=1)
+        match = pattern.match(normalized_line)
+        if match:
+            match_content = match.group("content")
+            break
+
+    if match_content is None:
         return False, "Priority Score の記載が見つかりません"
 
-    content = match.group("content")
+    content = match_content
     if "/" not in content:
         return False, "Priority Score の根拠が不足しています"
 


### PR DESCRIPTION
## Summary
- add regression coverage for Priority Score bullet and checkbox formatting
- strip leading bullet tokens before validating the Priority Score value

## Testing
- pytest tests/test_check_governance_gate.py -q

------
https://chatgpt.com/codex/tasks/task_e_68eee28c60a48321a730a62e77a53214