### PR TITLE
Adjust governance gate invalid priority test stub

### DIFF
--- a/workflow-cookbook/tests/test_check_governance_gate.py
+++ b/workflow-cookbook/tests/test_check_governance_gate.py
@@ -105,11 +105,10 @@ def test_main_returns_error_when_priority_score_invalid(tmp_path, monkeypatch, c
     )
     monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
     monkeypatch.setattr(module, "get_changed_paths", lambda refspec: [])
-    monkeypatch.setattr(
-        module,
-        "validate_priority_score",
-        lambda body: (False, "Priority Score validation failed"),
-    )
+    def stub_validate_priority_score(body: str | None) -> tuple[bool, str | None]:
+        return False, "Priority Score validation failed"
+
+    monkeypatch.setattr(module, "validate_priority_score", stub_validate_priority_score)
 
     exit_code = module.main()
     captured = capsys.readouterr()


### PR DESCRIPTION
## Summary
- stub validate_priority_score to return an invalid result tuple in the governance gate test
- assert module.main returns exit code 1 and emits the expected error message

## Testing
- pytest workflow-cookbook/tests/test_check_governance_gate.py::test_main_returns_error_when_priority_score_invalid

------
https://chatgpt.com/codex/tasks/task_e_68eee5feb77883218e29b6f535c088f6