### PR TITLE
Fix priority score content extraction

### DIFF
--- a/workflow-cookbook/tools/ci/check_governance_gate.py
+++ b/workflow-cookbook/tools/ci/check_governance_gate.py
@@ -102,7 +102,7 @@ def validate_priority_score(body: str | None) -> tuple[bool, str | None]:
     if not match:
         return False, "Priority Score の記載が見つかりません"
 
-    content = match.group("content")
+    content: str = match.group("content")
     if "/" not in content:
         return False, "Priority Score の根拠が不足しています"
 


### PR DESCRIPTION
## Summary
- assign the regex match result directly to the `content` variable in `validate_priority_score`

## Testing
- pytest workflow-cookbook/tests/test_check_governance_gate.py

------
https://chatgpt.com/codex/tasks/task_e_68eeea8e9fa08321917346f3ebefd45e