### PR TITLE
Improve governance gate forbidden path globbing

### DIFF
--- a/workflow-cookbook/tests/test_check_governance_gate.py
+++ b/workflow-cookbook/tests/test_check_governance_gate.py
@@ -24,6 +24,16 @@ from tools.ci.check_governance_gate import (
             ["/auth/**", "/core/schema/**"],
             ["auth/service.py", "core/schema/definitions.yml"],
         ),
+        (
+            """core/schema/v1/model.yaml\nnotes/todo.md""".splitlines(),
+            ["/core/schema/**"],
+            ["core/schema/v1/model.yaml"],
+        ),
+        (
+            """auth/sub/module.py\nfrontend/app.jsx""".splitlines(),
+            ["/auth/**"],
+            ["auth/sub/module.py"],
+        ),
     ],
 )
 def test_find_forbidden_matches(changed_paths, patterns, expected):


### PR DESCRIPTION
## Summary
- add coverage for nested directory paths in the governance gate tests
- switch forbidden path matching to use PurePosixPath glob semantics so `**` spans directories

## Testing
- pytest tests/test_check_governance_gate.py

------
https://chatgpt.com/codex/tasks/task_e_68ef3ba6ec488321bb7f3add7b66027a