### PR TITLE
Normalize governance gate path matching

### DIFF
--- a/workflow-cookbook/tests/test_check_governance_gate.py
+++ b/workflow-cookbook/tests/test_check_governance_gate.py
@@ -36,6 +36,21 @@ def test_find_forbidden_matches(changed_paths, patterns, expected):
     assert find_forbidden_matches(changed_paths, normalized) == expected
 
 
+def test_find_forbidden_matches_normalizes_patterns_and_paths():
+    changed_paths = ["./auth", "auth\\service.py", "docs/readme.md"]
+    patterns = ["/auth/**"]
+    assert find_forbidden_matches(changed_paths, patterns) == ["auth", "auth/service.py"]
+
+
+def test_find_forbidden_matches_preserves_result_order():
+    changed_paths = ["./auth", "core/schema/model.yaml", "logs/system.log"]
+    patterns = ["/auth/**", "/core/schema/**"]
+    assert find_forbidden_matches(changed_paths, patterns) == [
+        "auth",
+        "core/schema/model.yaml",
+    ]
+
+
 @pytest.mark.parametrize(
     "body",
     [


### PR DESCRIPTION
## Summary
- normalize forbidden path patterns before matching to support leading slashes and mixed separators
- streamline recursive glob detection while preserving existing ordering guarantees
- add regression tests covering path/pattern normalization and output ordering

## Testing
- `pytest tests/test_check_governance_gate.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ef456a154c83219a8b06ba1745e199