### PR TITLE
Annotate governance gate test for normalized path regression

### DIFF
--- a/workflow-cookbook/tests/test_check_governance_gate.py
+++ b/workflow-cookbook/tests/test_check_governance_gate.py
@@ -27,7 +27,7 @@ from tools.ci.check_governance_gate import (
         (
             """core/schema/v1/model.yaml\nauth/service/internal/api.py""".splitlines(),
             ["/core/schema/**", "/auth/**"],
-            ["core/schema/v1/model.yaml", "auth/service/internal/api.py"],
+            ["core/schema/v1/model.yaml", "auth/service/internal/api.py"],  # normalized パス。現行ロジックでは検知できずテスト失敗を想定。
         ),
     ],
 )


### PR DESCRIPTION
## Summary
- document the normalized forbidden path case in `test_find_forbidden_matches`
- note that the current implementation still fails to flag normalized paths

## Testing
- `pytest workflow-cookbook/tests/test_check_governance_gate.py::test_find_forbidden_matches -q` *(fails: NameError in current implementation)*

------
https://chatgpt.com/codex/tasks/task_e_68ef45692528832181eb9cc67bba3d44