### PR TITLE
Fix governance gate recursive pattern handling

### DIFF
--- a/workflow-cookbook/tests/test_check_governance_gate.py
+++ b/workflow-cookbook/tests/test_check_governance_gate.py
@@ -17,6 +17,7 @@ from tools.ci.check_governance_gate import (
 @pytest.mark.parametrize(
     "changed_paths, patterns, expected",
     [
+        ("core/schema".splitlines(), ["/core/schema/**"], ["core/schema"]),
         ("""core/schema/model.yaml\ndocs/guide.md""".splitlines(), ["/core/schema/**"], ["core/schema/model.yaml"]),
         ("""docs/readme.md\nops/runbook.md""".splitlines(), ["/core/schema/**"], []),
         (

--- a/workflow-cookbook/tools/ci/check_governance_gate.py
+++ b/workflow-cookbook/tools/ci/check_governance_gate.py
@@ -64,14 +64,13 @@ def get_changed_paths(refspec: str) -> List[str]:
 
 
 def find_forbidden_matches(paths: Iterable[str], patterns: Sequence[str]) -> List[str]:
-    normalized_patterns = [_normalize_pattern(pattern) for pattern in patterns]
+    normalized_patterns = [pattern.lstrip("./") for pattern in patterns]
     matches: List[str] = []
     for path in paths:
         normalized_path = path.lstrip("./")
         normalized_path = normalized_path.replace("\\", "/")
         posix_path = PurePosixPath(normalized_path)
-        for pattern in patterns:
-            normalized_pattern = pattern.lstrip("./")
+        for normalized_pattern in normalized_patterns:
             if normalized_pattern.endswith("/**"):
                 base_pattern = normalized_pattern[:-3].rstrip("/")
                 if not base_pattern:


### PR DESCRIPTION
## Summary
- normalize forbidden patterns in `find_forbidden_matches` without relying on undefined helpers
- add a regression case ensuring directory-level matches for `core/schema/**`

## Testing
- pytest tests/test_check_governance_gate.py -k forbidden --maxfail=1

------
https://chatgpt.com/codex/tasks/task_e_68ef4952a2908321bc2a165b7f3c20f3