### PR TITLE
Handle inline comments in governance forbidden patterns

### DIFF
--- a/workflow-cookbook/tests/test_check_governance_gate.py
+++ b/workflow-cookbook/tests/test_check_governance_gate.py
@@ -138,6 +138,21 @@ self_modification:
     assert load_forbidden_patterns(policy) == ["core/schema/**", "auth/**"]
 
 
+def test_load_forbidden_patterns_ignores_inline_comments(tmp_path):
+    policy = tmp_path / "policy.yaml"
+    policy.write_text(
+        """
+self_modification:
+  forbidden_paths:
+    - "/core/schema/**"  # コメント付き
+  require_human_approval:
+    - "/governance/**"
+"""
+    )
+
+    assert load_forbidden_patterns(policy) == ["core/schema/**"]
+
+
 def test_main_returns_error_when_priority_score_invalid(tmp_path, monkeypatch, capsys):
     from tools.ci import check_governance_gate as module
 


### PR DESCRIPTION
## Summary
- add regression test covering forbidden path entries with inline YAML comments
- strip inline comments and normalize patterns when loading governance policy

## Testing
- pytest workflow-cookbook/tests/test_check_governance_gate.py

------
https://chatgpt.com/codex/tasks/task_e_68ef66d7db148321874fbaf96d3bda88