### PR TITLE
Fix governance gate glob directory matching

### DIFF
--- a/workflow-cookbook/tests/test_check_governance_gate.py
+++ b/workflow-cookbook/tests/test_check_governance_gate.py
@@ -26,6 +26,11 @@ from tools.ci.check_governance_gate import (
             ["auth/service.py", "core/schema/definitions.yml"],
         ),
         (
+            ["core/schema/model.yaml"],
+            ["**/schema/**"],
+            ["core/schema/model.yaml"],
+        ),
+        (
             """core/schema/v1/model.yaml\nauth/service/internal/api.py""".splitlines(),
             ["/core/schema/**", "/auth/**"],
             ["core/schema/v1/model.yaml", "auth/service/internal/api.py"],  # normalized パス。現行ロジックでは検知できずテスト失敗を想定。

--- a/workflow-cookbook/tools/ci/check_governance_gate.py
+++ b/workflow-cookbook/tools/ci/check_governance_gate.py
@@ -121,10 +121,23 @@ def find_forbidden_matches(paths: Iterable[str], patterns: Sequence[str]) -> Lis
                 if not base_pattern:
                     matches.append(normalized_path)
                     break
-                base_path = PurePosixPath(base_pattern)
-                if posix_path == base_path or posix_path.is_relative_to(base_path):
-                    matches.append(normalized_path)
-                    break
+                contains_glob = any(char in base_pattern for char in "*?[]")
+                if contains_glob:
+                    matched = False
+                    for candidate in (posix_path,) + tuple(posix_path.parents):
+                        if candidate == PurePosixPath("."):
+                            continue
+                        if candidate.match(base_pattern):
+                            matches.append(normalized_path)
+                            matched = True
+                            break
+                    if matched:
+                        break
+                else:
+                    base_path = PurePosixPath(base_pattern)
+                    if posix_path == base_path or posix_path.is_relative_to(base_path):
+                        matches.append(normalized_path)
+                        break
             elif posix_path.match(normalized_pattern):
                 matches.append(normalized_path)
                 break


### PR DESCRIPTION
## Summary
- add a regression test covering schema glob patterns in the governance gate
- update `find_forbidden_matches` to handle globbed base directories for `/**` patterns and detect the base directory itself

## Testing
- pytest workflow-cookbook/tests/test_check_governance_gate.py

------
https://chatgpt.com/codex/tasks/task_e_68ef7588a6ec83218d27a5e60c5bd3c4