### PR TITLE
Fix governance gate glob handling for schema patterns

### DIFF
--- a/workflow-cookbook/tests/test_check_governance_gate.py
+++ b/workflow-cookbook/tests/test_check_governance_gate.py
@@ -25,10 +25,11 @@ from tools.ci.check_governance_gate import (
             ["/auth/**", "/core/schema/**"],
             ["auth/service.py", "core/schema/definitions.yml"],
         ),
-        (
+        pytest.param(
             ["core/schema/model.yaml"],
             ["**/schema/**"],
             ["core/schema/model.yaml"],
+            id="double_glob_schema",
         ),
         (
             """core/schema/v1/model.yaml\nauth/service/internal/api.py""".splitlines(),

--- a/workflow-cookbook/tools/ci/check_governance_gate.py
+++ b/workflow-cookbook/tools/ci/check_governance_gate.py
@@ -133,6 +133,9 @@ def find_forbidden_matches(paths: Iterable[str], patterns: Sequence[str]) -> Lis
                             break
                     if matched:
                         break
+                    if posix_path.match(normalized_pattern):
+                        matches.append(normalized_path)
+                        break
                 else:
                     base_path = PurePosixPath(base_pattern)
                     if posix_path == base_path or posix_path.is_relative_to(base_path):


### PR DESCRIPTION
## Summary
- add a test case covering a double-glob schema pattern in the governance gate check
- fall back to PurePosixPath.match when the base glob contains wildcards so that **/schema/** matches correctly

## Testing
- pytest workflow-cookbook/tests/test_check_governance_gate.py

------
https://chatgpt.com/codex/tasks/task_e_68ef7a01c9e08321b1152ffee11e1c75