### PR TITLE
Fix comment formatting in governance gate test

### DIFF
--- a/workflow-cookbook/tests/test_check_governance_gate.py
+++ b/workflow-cookbook/tests/test_check_governance_gate.py
@@ -34,7 +34,8 @@ from tools.ci.check_governance_gate import (
         (
             """core/schema/v1/model.yaml\nauth/service/internal/api.py""".splitlines(),
             ["/core/schema/**", "/auth/**"],
-            ["core/schema/v1/model.yaml", "auth/service/internal/api.py"],  # normalized パス。現行ロジックでは検知できずテスト失敗を想定。
+            ["core/schema/v1/model.yaml", "auth/service/internal/api.py"],  # normalized パス。現行ロジックでは検知できず
+            # テスト失敗を想定。
         ),
         (
             ["doc/config.yaml"],


### PR DESCRIPTION
## Summary
- ensure the normalized path comment in the governance gate test parameter is formatted as a proper comment line

## Testing
- pytest workflow-cookbook/tests/test_check_governance_gate.py

------
https://chatgpt.com/codex/tasks/task_e_68ef7f25c1a88321859340ac6585e108