### PR TITLE
Fix governance gate path normalization for repo-prefixed changes

### DIFF
--- a/workflow-cookbook/tests/test_check_governance_gate.py
+++ b/workflow-cookbook/tests/test_check_governance_gate.py
@@ -19,6 +19,11 @@ from tools.ci.check_governance_gate import (
     [
         ("core/schema".splitlines(), ["/core/schema/**"], ["core/schema"]),
         ("""core/schema/model.yaml\ndocs/guide.md""".splitlines(), ["/core/schema/**"], ["core/schema/model.yaml"]),
+        (
+            ["workflow-cookbook/core/schema/model.yaml"],
+            ["/core/schema/**"],
+            ["core/schema/model.yaml"],
+        ),
         ("""docs/readme.md\nops/runbook.md""".splitlines(), ["/core/schema/**"], []),
         (
             """auth/service.py\ncore/schema/definitions.yml""".splitlines(),
@@ -169,7 +174,7 @@ def test_main_returns_error_when_priority_score_invalid(tmp_path, monkeypatch, c
         encoding="utf-8",
     )
     monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
-    monkeypatch.setattr(module, "get_changed_paths", lambda refspec: [])
+    monkeypatch.setattr(module, "get_changed_paths", lambda refspec, **_: [])
     def stub_validate_priority_score(body: str | None) -> tuple[bool, str | None]:
         return False, "Priority Score validation failed"
 


### PR DESCRIPTION
## Summary
- add a regression test to ensure repo-prefixed paths under core/schema are caught by the governance gate
- normalize changed path collection to run from the repository root and strip the repo prefix

## Testing
- pytest workflow-cookbook/tests/test_check_governance_gate.py

------
https://chatgpt.com/codex/tasks/task_e_68efc5a148a48321bac571bdf518cb28