### PR TITLE
Ensure governance gate handles repo-root-prefixed paths

### DIFF
--- a/workflow-cookbook/tests/test_check_governance_gate.py
+++ b/workflow-cookbook/tests/test_check_governance_gate.py
@@ -77,6 +77,14 @@ def test_find_forbidden_matches_preserves_result_order():
     ]
 
 
+def test_find_forbidden_matches_detects_repo_root_prefixed_paths():
+    changed_paths = ["workflow-cookbook/core/schema/model.yaml"]
+    patterns = ["/core/schema/**"]
+    assert find_forbidden_matches(changed_paths, patterns) == [
+        "core/schema/model.yaml"
+    ]
+
+
 def test_get_changed_paths_normalizes_subdirectory_paths(monkeypatch):
     repo_root = Path(__file__).resolve().parents[1]
 

--- a/workflow-cookbook/tools/ci/check_governance_gate.py
+++ b/workflow-cookbook/tools/ci/check_governance_gate.py
@@ -107,26 +107,20 @@ def load_forbidden_patterns(policy_path: Path) -> List[str]:
 
 
 def get_changed_paths(refspec: str) -> List[str]:
-    repo_root = Path(__file__).resolve().parents[2]
     result = subprocess.run(
         ["git", "diff", "--name-only", refspec],
         check=True,
         capture_output=True,
         text=True,
         encoding="utf-8",
-        cwd=repo_root,
+        cwd=REPO_ROOT,
     )
     normalized_paths: List[str] = []
-    repo_root_name = repo_root.name
     for line in result.stdout.splitlines():
         stripped = line.strip()
         if not stripped:
             continue
-        posix_path = PurePosixPath(stripped)
-        parts = posix_path.parts
-        if parts and parts[0] == repo_root_name:
-            posix_path = PurePosixPath(*parts[1:])
-        normalized_paths.append(str(posix_path))
+        normalized_paths.append(_normalize_path(stripped))
     return normalized_paths
 def find_forbidden_matches(paths: Iterable[str], patterns: Sequence[str]) -> List[str]:
     normalized_patterns = [_normalize_pattern(pattern) for pattern in patterns]


### PR DESCRIPTION
## Summary
- add regression coverage for repo-root-prefixed diff paths in the governance gate tests
- normalize git diff output via the shared path normalizer while forcing the diff to run from the workflow-cookbook repo root

## Testing
- pytest workflow-cookbook/tests/test_check_governance_gate.py

------
https://chatgpt.com/codex/tasks/task_e_68efc98ae5288321bd86d215785aa87d