### PR TITLE
Fix governance gate repo root handling and add regression test

### DIFF
--- a/workflow-cookbook/tools/ci/check_governance_gate.py
+++ b/workflow-cookbook/tools/ci/check_governance_gate.py
@@ -106,14 +106,15 @@ def load_forbidden_patterns(policy_path: Path) -> List[str]:
     return patterns
 
 
-def get_changed_paths(refspec: str) -> List[str]:
+def get_changed_paths(refspec: str, repo_root: Path | None = None) -> List[str]:
+    root = repo_root or REPO_ROOT
     result = subprocess.run(
         ["git", "diff", "--name-only", refspec],
         check=True,
         capture_output=True,
         text=True,
         encoding="utf-8",
-        cwd=REPO_ROOT,
+        cwd=root,
     )
     normalized_paths: List[str] = []
     for line in result.stdout.splitlines():


### PR DESCRIPTION
## Summary
- add a regression test that exercises check_governance_gate.main with monkeypatched subprocess and event payload
- update get_changed_paths to accept an optional repo_root so main can forward the argument without raising a TypeError

## Testing
- pytest workflow-cookbook/tests/test_check_governance_gate.py

------
https://chatgpt.com/codex/tasks/task_e_68efcf322c848321bd6e60dec8862eab