### PR TITLE
Handle inline comments on governance gate forbidden_paths key

### DIFF
--- a/workflow-cookbook/tests/test_check_governance_gate.py
+++ b/workflow-cookbook/tests/test_check_governance_gate.py
@@ -238,6 +238,21 @@ self_modification:
     assert load_forbidden_patterns(policy) == ["core/schema/**"]
 
 
+def test_load_forbidden_patterns_handles_commented_key(tmp_path):
+    policy = tmp_path / "policy.yaml"
+    policy.write_text(
+        """
+self_modification:
+  forbidden_paths:  # コメント
+    - "/core/schema/**"
+  require_human_approval:
+    - "/governance/**"
+"""
+    )
+
+    assert load_forbidden_patterns(policy) == ["core/schema/**"]
+
+
 def test_main_returns_error_when_priority_score_invalid(tmp_path, monkeypatch, capsys):
     from tools.ci import check_governance_gate as module
 

--- a/workflow-cookbook/tools/ci/check_governance_gate.py
+++ b/workflow-cookbook/tools/ci/check_governance_gate.py
@@ -72,9 +72,12 @@ def load_forbidden_patterns(policy_path: Path) -> List[str]:
         if not stripped_line or stripped_line.startswith("#"):
             continue
         indent = len(raw_line) - len(raw_line.lstrip(" "))
+        line_without_comments = _strip_inline_comment(stripped_line).rstrip()
+        if not line_without_comments:
+            continue
 
-        if stripped_line.endswith(":"):
-            key = stripped_line[:-1].strip()
+        if line_without_comments.endswith(":"):
+            key = line_without_comments[:-1].strip()
             if indent == 0:
                 in_self_modification = key == "self_modification"
                 in_forbidden_paths = False


### PR DESCRIPTION
## Summary
- add a regression test ensuring policies with inline comments on forbidden_paths are parsed
- strip inline comments before matching policy keys in load_forbidden_patterns so commented keys are recognized

## Testing
- pytest workflow-cookbook/tests/test_check_governance_gate.py

------
https://chatgpt.com/codex/tasks/task_e_68efdbb1e8688321bc0dd543dfa282c2