### PR TITLE
Handle hashes inside quoted front matter values

### DIFF
--- a/workflow-cookbook/tests/test_check_front_matter.py
+++ b/workflow-cookbook/tests/test_check_front_matter.py
@@ -46,7 +46,10 @@ def test_validate_markdown_front_matter_pass(repo_root: Path) -> None:
     assert validate_markdown_front_matter(repo_root) == {}
 
 
-@pytest.mark.parametrize("owner_value", ['"Team #1"', "'Team #1'"])
+@pytest.mark.parametrize(
+    "owner_value",
+    ['"Team #1"', "'Team #1'", '"#platform-team"'],
+)
 def test_validate_markdown_front_matter_owner_with_hash(repo_root: Path, owner_value: str) -> None:
     _write_markdown(
         repo_root / "README.md",
@@ -60,6 +63,29 @@ def test_validate_markdown_front_matter_owner_with_hash(repo_root: Path, owner_v
     )
 
     assert validate_markdown_front_matter(repo_root) == {}
+
+
+@pytest.mark.parametrize(
+    "owner_value",
+    ['"#platform-team"', '"Team #1"'],
+)
+def test_validate_markdown_front_matter_owner_hash_not_missing(
+    repo_root: Path, owner_value: str
+) -> None:
+    _write_markdown(
+        repo_root / "README.md",
+        (
+            ("intent_id", "INT-125"),
+            ("owner", owner_value),
+            ("status", "active"),
+            ("last_reviewed_at", "2024-01-03"),
+            ("next_review_due", "2024-02-03"),
+        ),
+    )
+
+    missing = validate_markdown_front_matter(repo_root)
+
+    assert repo_root / "README.md" not in missing
 
 
 def test_validate_markdown_front_matter_missing_fields(repo_root: Path) -> None:

--- a/workflow-cookbook/tools/ci/check_front_matter.py
+++ b/workflow-cookbook/tools/ci/check_front_matter.py
@@ -64,27 +64,7 @@ def _parse_fields(front_matter_lines: Iterable[str]) -> Dict[str, str]:
         if not stripped or stripped.startswith("#") or ":" not in stripped:
             continue
         key, value = stripped.split(":", 1)
-        value = value.strip()
-        in_single_quote = False
-        in_double_quote = False
-        escaped = False
-        for index, char in enumerate(value):
-            if escaped:
-                escaped = False
-                continue
-            if char == "\\" and in_double_quote:
-                escaped = True
-                continue
-            if char == "'" and not in_double_quote:
-                in_single_quote = not in_single_quote
-                continue
-            if char == '"' and not in_single_quote:
-                in_double_quote = not in_double_quote
-                continue
-            if char == "#" and not in_single_quote and not in_double_quote:
-                if index == 0 or value[index - 1].isspace():
-                    value = value[:index].rstrip()
-                    break
+        value = _strip_inline_comment(value.strip())
         data[key.strip()] = value
     return data
 


### PR DESCRIPTION
## Summary
- expand the front matter tests to cover owner values containing hash characters and ensure they are not treated as missing
- reuse the inline comment stripping helper in the front matter parser so hashes inside quoted values are preserved

## Testing
- pytest workflow-cookbook/tests/test_check_front_matter.py

------
https://chatgpt.com/codex/tasks/task_e_68eff413b35483219f5fbdf419904baf