### PR TITLE
Handle indented priority score entries

### DIFF
--- a/workflow-cookbook/tests/test_check_governance_gate.py
+++ b/workflow-cookbook/tests/test_check_governance_gate.py
@@ -151,6 +151,7 @@ def test_validate_priority_score(body, expected, message):
         "+ Priority Score: 9 / プラス記号",
         "- [ ] Priority Score: 4 / 未チェック",
         "- [x] Priority Score: 8 / チェック済み",
+        "    Priority Score: 6 / インデント付き",
     ],
 )
 def test_validate_priority_score_valid(body):

--- a/workflow-cookbook/tools/ci/check_governance_gate.py
+++ b/workflow-cookbook/tools/ci/check_governance_gate.py
@@ -188,7 +188,7 @@ def validate_priority_score(body: str | None) -> tuple[bool, str | None]:
         return False, "Priority Score セクションが見つかりません"
 
     normalized_body = "\n".join(
-        BULLET_PATTERN.sub("", line) for line in body.splitlines()
+        BULLET_PATTERN.sub("", line).lstrip() for line in body.splitlines()
     )
     pattern = re.compile(r"^Priority Score:\s*(?P<content>.+)$", re.MULTILINE)
     match = pattern.search(normalized_body)


### PR DESCRIPTION
## Summary
- cover indented Priority Score entries in governance gate validation tests
- strip leading whitespace before matching Priority Score after removing bullets

## Testing
- pytest tests/test_check_governance_gate.py::test_validate_priority_score_valid

------
https://chatgpt.com/codex/tasks/task_e_68effb0e987083218c9b253f5d0dd417