### PR TITLE
chore: run workflows from cookbook dir

### DIFF
--- a/.github/workflows/reflection.yml
+++ b/.github/workflows/reflection.yml
@@ -5,6 +5,9 @@ on:
     types: [completed]
   schedule:
     - cron: "0 3 * * *"   # 毎日3:00 UTC
+defaults:
+  run:
+    working-directory: workflow-cookbook
 jobs:
   reflect:
     runs-on: ubuntu-latest
@@ -29,7 +32,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: test-logs
-          path: logs
+          path: workflow-cookbook/logs
           run-id: ${{ steps.artifact-meta.outputs.run_id }}
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -38,7 +41,7 @@ jobs:
       - name: Analyze logs → report
         run: |
           python -m pip install --upgrade pip
-          python scripts/analyze.py
+          python ../scripts/analyze.py
       - name: Commit report
         run: |
           git config user.name "reflect-bot"
@@ -47,11 +50,11 @@ jobs:
           git commit -m "chore(report): reflection report [skip ci]" || echo "no changes"
           git push || true
       - name: Open issue if needed (draft memo)
-        if: ${{ hashFiles('reports/issue_suggestions.md') != '' }}
+        if: ${{ hashFiles('workflow-cookbook/reports/issue_suggestions.md') != '' }}
         uses: peter-evans/create-issue-from-file@v5
         with:
           title: "反省TODO ${{ github.run_id }}"
-          content-filepath: reports/issue_suggestions.md
+          content-filepath: workflow-cookbook/reports/issue_suggestions.md
           labels: reflection, needs-triage
       - name: Open draft PR with doc/test tweaks (disabled)
         if: ${{ false }}  # デチューン：無効化

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches: ["**"]
   pull_request:
+defaults:
+  run:
+    working-directory: workflow-cookbook
 jobs:
   run:
     runs-on: ubuntu-latest
@@ -18,4 +21,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-logs
-          path: logs
+          path: workflow-cookbook/logs


### PR DESCRIPTION
## Summary
- set both test and reflection workflows to run from the workflow-cookbook subdirectory
- adjust artifact paths and log analysis command to match the new working directory

## Testing
- act workflow_dispatch -W .github/workflows/test.yml *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68effe330820832198197b1031038324