### PR TITLE
Refactor: relocate analyze script

### DIFF
--- a/.github/workflows/reflection.yml
+++ b/.github/workflows/reflection.yml
@@ -29,17 +29,19 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: test-logs
-          path: logs
+          path: workflow-cookbook/logs
           run-id: ${{ steps.artifact-meta.outputs.run_id }}
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Analyze logs → report
+        working-directory: workflow-cookbook
         run: |
           python -m pip install --upgrade pip
           python scripts/analyze.py
       - name: Commit report
+        working-directory: workflow-cookbook
         run: |
           git config user.name "reflect-bot"
           git config user.email "bot@example.com"
@@ -47,11 +49,11 @@ jobs:
           git commit -m "chore(report): reflection report [skip ci]" || echo "no changes"
           git push || true
       - name: Open issue if needed (draft memo)
-        if: ${{ hashFiles('reports/issue_suggestions.md') != '' }}
+        if: ${{ hashFiles('workflow-cookbook/reports/issue_suggestions.md') != '' }}
         uses: peter-evans/create-issue-from-file@v5
         with:
           title: "反省TODO ${{ github.run_id }}"
-          content-filepath: reports/issue_suggestions.md
+          content-filepath: workflow-cookbook/reports/issue_suggestions.md
           labels: reflection, needs-triage
       - name: Open draft PR with doc/test tweaks (disabled)
         if: ${{ false }}  # デチューン：無効化

--- a/workflow-cookbook/scripts/analyze.py
+++ b/workflow-cookbook/scripts/analyze.py
@@ -10,9 +10,10 @@ from typing import Final
 
 StatusMap = dict[str, set[str]]
 
-LOG: Final[pathlib.Path] = pathlib.Path("logs/test.jsonl")
-REPORT: Final[pathlib.Path] = pathlib.Path("reports/today.md")
-ISSUE_OUT: Final[pathlib.Path] = pathlib.Path("reports/issue_suggestions.md")
+BASE_DIR: Final[pathlib.Path] = pathlib.Path(__file__).resolve().parents[1]
+LOG: Final[pathlib.Path] = BASE_DIR / "logs" / "test.jsonl"
+REPORT: Final[pathlib.Path] = BASE_DIR / "reports" / "today.md"
+ISSUE_OUT: Final[pathlib.Path] = BASE_DIR / "reports" / "issue_suggestions.md"
 
 
 def load_results() -> tuple[list[str], list[int], list[str], StatusMap]:

--- a/workflow-cookbook/tests/test_analyze_script.py
+++ b/workflow-cookbook/tests/test_analyze_script.py
@@ -12,10 +12,11 @@ import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+COOKBOOK_ROOT = REPO_ROOT / "workflow-cookbook"
 
 
 def load_analyze_module() -> ModuleType:
-    module_path = REPO_ROOT / "scripts" / "analyze.py"
+    module_path = COOKBOOK_ROOT / "scripts" / "analyze.py"
     spec = importlib.util.spec_from_file_location("analyze", module_path)
     if spec is None or spec.loader is None:
         pytest.fail("Failed to load analyze.py spec")
@@ -28,7 +29,7 @@ def load_analyze_module() -> ModuleType:
 
 
 def test_analyze_script_compiles() -> None:
-    script_path = REPO_ROOT / "scripts" / "analyze.py"
+    script_path = COOKBOOK_ROOT / "scripts" / "analyze.py"
     py_compile.compile(str(script_path), doraise=True)
 
 


### PR DESCRIPTION
## Summary
- move the analyze script under workflow-cookbook/scripts and anchor its log/report paths to the cookbook directory
- update the analyze script loader test and reflection workflow to work with the new layout

## Testing
- pytest workflow-cookbook/tests/test_analyze_script.py

------
https://chatgpt.com/codex/tasks/task_e_68effe33d2688321870af1ad23660e90