### PR TITLE
Add regression test for workflow defaults

### DIFF
--- a/.github/workflows/reflection.yml
+++ b/.github/workflows/reflection.yml
@@ -42,7 +42,7 @@ jobs:
         working-directory: workflow-cookbook
         run: |
           python -m pip install --upgrade pip
-          python ../scripts/analyze.py
+          python scripts/analyze.py
       - name: Commit report
         working-directory: workflow-cookbook
         run: |

--- a/workflow-cookbook/tests/test_workflows_defaults.py
+++ b/workflow-cookbook/tests/test_workflows_defaults.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+from typing import IO, Any, Dict
+
+try:
+    import yaml  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback for test envs without PyYAML
+    class _MiniYAML:
+        def safe_load(self, stream: IO[str] | str) -> Dict[str, Any]:
+            if hasattr(stream, "read"):
+                content = stream.read()
+            else:
+                content = str(stream)
+
+            root: Dict[str, Any] = {}
+            stack: list[Dict[str, Any]] = [root]
+            indents = [0]
+
+            for raw_line in content.splitlines():
+                stripped = raw_line.lstrip()
+                if not stripped or stripped.startswith("#"):
+                    continue
+
+                indent = len(raw_line) - len(stripped)
+                key, _, value = stripped.partition(":")
+                value = value.strip()
+
+                while indent < indents[-1]:
+                    stack.pop()
+                    indents.pop()
+
+                if value == "":
+                    new_map: Dict[str, Any] = {}
+                    stack[-1][key] = new_map
+                    stack.append(new_map)
+                    indents.append(indent + 2)
+                else:
+                    if value.startswith("\"") and value.endswith("\""):
+                        value = value[1:-1]
+                    stack[-1][key] = value
+
+            return root
+
+    yaml = _MiniYAML()  # type: ignore
+
+
+def load_workflow(name: str) -> dict:
+    root = Path(__file__).resolve().parents[2]
+    workflow_path = root / ".github" / "workflows" / name
+    with workflow_path.open("r", encoding="utf-8") as file:
+        return yaml.safe_load(file)
+
+
+def test_workflow_defaults_run_working_directory() -> None:
+    for workflow_name in ("test.yml", "reflection.yml"):
+        workflow = load_workflow(workflow_name)
+        assert workflow["defaults"]["run"]["working-directory"] == "workflow-cookbook"


### PR DESCRIPTION
## Summary
- add a regression test that ensures the test and reflection workflows set defaults.run.working-directory to workflow-cookbook
- fix the reflection workflow's analyze step to use the workflow-level working directory when invoking the analyzer script

## Testing
- pytest workflow-cookbook/tests/test_workflows_defaults.py

------
https://chatgpt.com/codex/tasks/task_e_68f002fa42288321b08d001db9f6da65