### PR TITLE
Align analyze script paths with workflow directory

### DIFF
--- a/.github/workflows/reflection.yml
+++ b/.github/workflows/reflection.yml
@@ -42,7 +42,7 @@ jobs:
         working-directory: workflow-cookbook
         run: |
           python -m pip install --upgrade pip
-          python ../scripts/analyze.py
+          python scripts/analyze.py
       - name: Commit report
         working-directory: workflow-cookbook
         run: |

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,7 +5,7 @@
 
 - `governance/policy.yaml`
 - `reflection.yaml`
-- `scripts/analyze.py`
+- `workflow-cookbook/scripts/analyze.py`
 - `.github/workflows/test.yml`
 - `.github/workflows/reflection.yml`
 - `.github/workflows/pr_gate.yml`

--- a/docs/day8/design/03_architecture.md
+++ b/docs/day8/design/03_architecture.md
@@ -2,7 +2,7 @@
 
 ## コンポーネント
 - **Collector**: CI テストやツールから JSONL ログを収集
-- **Analyzer**: `scripts/analyze.py` がメトリクス算出と Why-Why 草案生成
+- **Analyzer**: `workflow-cookbook/scripts/analyze.py` がメトリクス算出と Why-Why 草案生成
 - **Reporter**: `reports/today.md` と `reports/issue_suggestions.md` を生成
 - **Proposer**: Issue/ドラフトPR を“提案のみ”で作成（自動改変なし）
 - **Governance**: `governance/policy.yaml` に行動制約・SLO

--- a/docs/day8/examples/10_examples.md
+++ b/docs/day8/examples/10_examples.md
@@ -56,12 +56,12 @@ jobs:
       - name: Analyze logs → report
         run: |
           python -m pip install --upgrade pip
-          python scripts/analyze.py
+          python workflow-cookbook/scripts/analyze.py
       - name: Commit report
         run: |
           git config user.name "reflect-bot"
           git config user.email "bot@example.com"
-          git add reports/today.md
+          git add workflow-cookbook/reports/today.md
           git commit -m "chore(report): reflection report [skip ci]" || echo "no changes"
           git push || true
 ```

--- a/docs/day8/spec/02_spec.md
+++ b/docs/day8/spec/02_spec.md
@@ -4,7 +4,7 @@
 - `.github/workflows/` : `test.yml`, `reflection.yml`（必要に応じ `pr_gate.yml`）
 - `workflow-cookbook/`
   - `reflection.yaml` （反省DSL）
-  - `scripts/analyze.py` （ログ→レポート）
+  - `workflow-cookbook/scripts/analyze.py` （ログ→レポート）
   - `logs/` / `reports/` / `docs/`
 
 ## 反省DSL（例）

--- a/workflow-cookbook/tests/test_analyze_script.py
+++ b/workflow-cookbook/tests/test_analyze_script.py
@@ -11,12 +11,11 @@ from types import ModuleType
 import pytest
 
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
-COOKBOOK_ROOT = REPO_ROOT / "workflow-cookbook"
+WORKFLOW_ROOT = Path(__file__).resolve().parents[1]
 
 
 def load_analyze_module() -> ModuleType:
-    module_path = COOKBOOK_ROOT / "scripts" / "analyze.py"
+    module_path = WORKFLOW_ROOT / "scripts" / "analyze.py"
     spec = importlib.util.spec_from_file_location("analyze", module_path)
     if spec is None or spec.loader is None:
         pytest.fail("Failed to load analyze.py spec")
@@ -29,7 +28,7 @@ def load_analyze_module() -> ModuleType:
 
 
 def test_analyze_script_compiles() -> None:
-    script_path = COOKBOOK_ROOT / "scripts" / "analyze.py"
+    script_path = WORKFLOW_ROOT / "scripts" / "analyze.py"
     py_compile.compile(str(script_path), doraise=True)
 
 


### PR DESCRIPTION
## Summary
- load the analyze.py module via the workflow-cookbook directory in tests
- update the reflection workflow and docs to call the script from its new location

## Testing
- pytest workflow-cookbook/tests/test_analyze_script.py

------
https://chatgpt.com/codex/tasks/task_e_68f002f9c2988321bb15188c9c63a8b0