### PR TITLE
Fix analyze script base path for logs and reports

### DIFF
--- a/workflow-cookbook/scripts/analyze.py
+++ b/workflow-cookbook/scripts/analyze.py
@@ -10,7 +10,7 @@ from typing import Final
 
 StatusMap = dict[str, set[str]]
 
-BASE_DIR: Final[pathlib.Path] = pathlib.Path(__file__).resolve().parents[1]
+BASE_DIR: Final[pathlib.Path] = pathlib.Path(__file__).resolve().parents[2]
 LOG: Final[pathlib.Path] = BASE_DIR / "logs" / "test.jsonl"
 REPORT: Final[pathlib.Path] = BASE_DIR / "reports" / "today.md"
 ISSUE_OUT: Final[pathlib.Path] = BASE_DIR / "reports" / "issue_suggestions.md"


### PR DESCRIPTION
## Summary
- update analyze.py to resolve base directory from the repository root so log and report paths point to top-level logs/ and reports/

## Testing
- pytest workflow-cookbook/tests/test_analyze_script.py

------
https://chatgpt.com/codex/tasks/task_e_68f004da4d1c8321af5ecdb1be4ae34d