### PR TITLE
refactor: ensure analyze script uses repository root paths

### DIFF
--- a/workflow-cookbook/scripts/analyze.py
+++ b/workflow-cookbook/scripts/analyze.py
@@ -3,17 +3,17 @@ from __future__ import annotations
 import datetime
 import json
 import math
-import pathlib
 import statistics
 from collections import Counter
+from pathlib import Path
 from typing import Final
 
 StatusMap = dict[str, set[str]]
 
-BASE_DIR: Final[pathlib.Path] = pathlib.Path(__file__).resolve().parents[2]
-LOG: Final[pathlib.Path] = BASE_DIR / "logs" / "test.jsonl"
-REPORT: Final[pathlib.Path] = BASE_DIR / "reports" / "today.md"
-ISSUE_OUT: Final[pathlib.Path] = BASE_DIR / "reports" / "issue_suggestions.md"
+BASE_DIR: Final[Path] = Path(__file__).resolve().parents[2]
+LOG: Final[Path] = BASE_DIR / "logs" / "test.jsonl"
+REPORT: Final[Path] = BASE_DIR / "reports" / "today.md"
+ISSUE_OUT: Final[Path] = BASE_DIR / "reports" / "issue_suggestions.md"
 
 
 def load_results() -> tuple[list[str], list[int], list[str], StatusMap]:


### PR DESCRIPTION
## Summary
- update analyze.py to resolve the repository root with Path(__file__).resolve().parents[2]
- ensure log and report paths are built from Path objects targeting the top-level logs/ and reports/ folders

## Testing
- pytest workflow-cookbook/tests/test_analyze_script.py

------
https://chatgpt.com/codex/tasks/task_e_68f006bd28ac83218925ffb2d84c076a