### PR TITLE
Fix reflection workflow analyze step invocation

### DIFF
--- a/.github/workflows/reflection.yml
+++ b/.github/workflows/reflection.yml
@@ -41,7 +41,6 @@ jobs:
       - name: Analyze logs → report
         working-directory: workflow-cookbook
         run: |
-          python -m pip install --upgrade pip
           python scripts/analyze.py
       - name: Commit report
         working-directory: workflow-cookbook

--- a/workflow-cookbook/tests/test_workflows_reflection.py
+++ b/workflow-cookbook/tests/test_workflows_reflection.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_reflection_workflow_analyze_step_runs_analyze_script() -> None:
+    workflow_path = (
+        Path(__file__).resolve().parents[2]
+        / ".github"
+        / "workflows"
+        / "reflection.yml"
+    )
+    content = workflow_path.read_text(encoding="utf-8")
+
+    expected_block = (
+        "      - name: Analyze logs → report\n"
+        "        working-directory: workflow-cookbook\n"
+        "        run: |\n"
+        "          python scripts/analyze.py\n"
+    )
+
+    assert expected_block in content


### PR DESCRIPTION
## Summary
- add a regression test that asserts the reflection workflow invokes the analyze script directly
- update the reflection workflow to run python scripts/analyze.py without extra setup commands

## Testing
- pytest workflow-cookbook/tests/test_workflows_reflection.py

------
https://chatgpt.com/codex/tasks/task_e_68f006bd32388321957bfcd7d74562ea