### PR TITLE
Move reflection manifest into workflow cookbook directory

### DIFF
--- a/workflow-cookbook/reflection.yaml
+++ b/workflow-cookbook/reflection.yaml
@@ -1,6 +1,6 @@
 targets:
   - name: unit
-    logs: ["logs/test.jsonl"]
+    logs: ["../logs/test.jsonl"]
 metrics:
   - pass_rate
   - duration_p95
@@ -14,5 +14,5 @@ actions:
   open_pr_as_draft: true
   auto_fix: false         # 自動修正しない（安全デチューン）
 report:
-  output: "reports/today.md"
+  output: "../reports/today.md"
   include_why_why: true

--- a/workflow-cookbook/tests/test_reflection_layout.py
+++ b/workflow-cookbook/tests/test_reflection_layout.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+
+def test_reflection_manifest_present() -> None:
+    project_root = Path(__file__).resolve().parents[1]
+    reflection_manifest = project_root / "reflection.yaml"
+    assert reflection_manifest.exists(), "workflow-cookbook/reflection.yaml が存在する必要があります"


### PR DESCRIPTION
## Summary
- add a layout test that ensures workflow-cookbook/reflection.yaml is present
- relocate reflection.yaml into workflow-cookbook/ and adjust referenced paths for logs and reports

## Testing
- pytest workflow-cookbook/tests/test_reflection_layout.py

------
https://chatgpt.com/codex/tasks/task_e_68f007202b308321a9303effb6179d3f