### PR TITLE
Fix analyze script directories to use workflow-cookbook paths

### DIFF
--- a/workflow-cookbook/scripts/analyze.py
+++ b/workflow-cookbook/scripts/analyze.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 StatusMap = dict[str, set[str]]
 
-BASE_DIR: Final[Path] = Path(__file__).resolve().parents[2]
+BASE_DIR: Final[Path] = Path(__file__).resolve().parents[1]
 LOG: Final[Path] = BASE_DIR / "logs" / "test.jsonl"
 REPORT: Final[Path] = BASE_DIR / "reports" / "today.md"
 ISSUE_OUT: Final[Path] = BASE_DIR / "reports" / "issue_suggestions.md"


### PR DESCRIPTION
## Summary
- update the analyze script's base directory to resolve relative to the workflow-cookbook folder
- ensure log and report paths point into workflow-cookbook/logs and workflow-cookbook/reports

## Testing
- pytest workflow-cookbook/tests/test_analyze_script.py

------
https://chatgpt.com/codex/tasks/task_e_68f00ac71c1c8321b6cde65681cff0ca