### PR TITLE
Handle missing test logs artifact gracefully

### DIFF
--- a/.github/workflows/reflection.yml
+++ b/.github/workflows/reflection.yml
@@ -34,6 +34,7 @@ jobs:
           name: test-logs
           path: workflow-cookbook/logs
           run-id: ${{ steps.artifact-meta.outputs.run_id }}
+          if-no-artifact-found: warn
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/workflow-cookbook/tests/test_workflows_reflection.py
+++ b/workflow-cookbook/tests/test_workflows_reflection.py
@@ -20,3 +20,17 @@ def test_reflection_workflow_analyze_step_runs_analyze_script() -> None:
     )
 
     assert expected_block in content
+
+
+def test_reflection_workflow_download_step_warns_when_artifact_missing() -> None:
+    workflow_path = (
+        Path(__file__).resolve().parents[2]
+        / ".github"
+        / "workflows"
+        / "reflection.yml"
+    )
+    content = workflow_path.read_text(encoding="utf-8")
+
+    expected_line = "          if-no-artifact-found: warn\n"
+
+    assert expected_line in content


### PR DESCRIPTION
## Summary
- warn instead of failing when the reflection workflow cannot find the test logs artifact
- add a regression test to ensure the workflow keeps the warning configuration

## Testing
- pytest tests/test_workflows_reflection.py

------
https://chatgpt.com/codex/tasks/task_e_68f00a7def188321b2f5258ca1f4a711