### PR TITLE
fix: adjust analyze script paths

### DIFF
--- a/workflow-cookbook/scripts/analyze.py
+++ b/workflow-cookbook/scripts/analyze.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 StatusMap = dict[str, set[str]]
 
-BASE_DIR: Final[Path] = Path(__file__).resolve().parents[2]
+BASE_DIR: Final[Path] = Path(__file__).resolve().parents[1]
 LOG: Final[Path] = BASE_DIR / "logs" / "test.jsonl"
 REPORT: Final[Path] = BASE_DIR / "reports" / "today.md"
 ISSUE_OUT: Final[Path] = BASE_DIR / "reports" / "issue_suggestions.md"


### PR DESCRIPTION
## Summary
- ensure the analyze script resolves paths from the workflow-cookbook directory so logs and reports live under the repo

## Testing
- pytest workflow-cookbook/tests/test_analyze_script.py workflow-cookbook/tests/test_workflows_reflection.py

------
https://chatgpt.com/codex/tasks/task_e_68f02d8e8da48321b733207e6825dc71