### PR TITLE
Add coverage for reflection manifest path

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,7 +4,7 @@
 最低限必要なのは次の通り：
 
 - `governance/policy.yaml`
-- `reflection.yaml`
+- `workflow-cookbook/reflection.yaml`
 - `workflow-cookbook/scripts/analyze.py`
 - `.github/workflows/test.yml`
 - `.github/workflows/reflection.yml`
@@ -24,5 +24,5 @@
 
 ## 注意
 - `CODEOWNERS` を適切なユーザー/チームに設定してください。
-- `reflection.yaml` の `analysis.max_tokens` を 0 にしているため、初日は LLM を使いません。
+- `workflow-cookbook/reflection.yaml` の `analysis.max_tokens` を 0 にしているため、初日は LLM を使いません。
   必要に応じて `engine: llm` と合わせて有効化してください。

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Day8 は「観測 → 反省 → 提案」のループを CI に組み込み、�
 Day8 を新しいリポジトリへ導入する際は、[`INSTALL.md`](INSTALL.md) の手順に従ってワークフローや初期ファイルをルートに配置してください。GitHub Actions では `test` → `reflection` → `pr_gate` の順で実行され、安全デチューンされた反省レポートを生成します。
 
 ## 使い方のヒント
-- 初期状態では `reflection.yaml` の `analysis.max_tokens` が 0 のため LLM 呼び出しは抑制されています。必要に応じて `engine` 設定と合わせて有効化してください。
+- 初期状態では `workflow-cookbook/reflection.yaml` の `analysis.max_tokens` が 0 のため LLM 呼び出しは抑制されています。必要に応じて `engine` 設定と合わせて有効化してください。
 - 生成されたレポート（`reports/` 配下）と提案を確認し、人間が修正 PR を作成する運用を前提としています。
 
 ---

--- a/docs/day8/spec/02_spec.md
+++ b/docs/day8/spec/02_spec.md
@@ -3,7 +3,7 @@
 ## ディレクトリ標準
 - `.github/workflows/` : `test.yml`, `reflection.yml`（必要に応じ `pr_gate.yml`）
 - `workflow-cookbook/`
-  - `reflection.yaml` （反省DSL）
+  - `workflow-cookbook/reflection.yaml` （反省DSL）
   - `workflow-cookbook/scripts/analyze.py` （ログ→レポート）
   - `logs/` / `reports/` / `docs/`
 

--- a/workflow-cookbook/tests/test_workflows_defaults.py
+++ b/workflow-cookbook/tests/test_workflows_defaults.py
@@ -50,6 +50,14 @@ def load_workflow(name: str) -> dict:
         return yaml.safe_load(file)
 
 
+def test_reflection_manifest_path() -> None:
+    project_root = Path(__file__).resolve().parents[1]
+    reflection_manifest = project_root / "reflection.yaml"
+    assert (
+        reflection_manifest.exists()
+    ), "workflow-cookbook/reflection.yaml が存在する必要があります"
+
+
 def test_workflow_defaults_run_working_directory() -> None:
     for workflow_name in ("test.yml", "reflection.yml"):
         workflow = load_workflow(workflow_name)


### PR DESCRIPTION
## Summary
- add a regression test to ensure workflow defaults expect workflow-cookbook/reflection.yaml
- update docs to reference the new workflow-cookbook/reflection.yaml location

## Testing
- pytest workflow-cookbook/tests/test_workflows_defaults.py

------
https://chatgpt.com/codex/tasks/task_e_68f02ddc8de083218c135783e20a7c67