### PR TITLE
Ensure analyze script uses workflow root paths

### DIFF
--- a/workflow-cookbook/scripts/analyze.py
+++ b/workflow-cookbook/scripts/analyze.py
@@ -8,11 +8,9 @@ from collections import Counter
 from pathlib import Path
 from typing import Final
 
-from pathlib import Path
-
 StatusMap = dict[str, set[str]]
 
-BASE_DIR: Final[Path] = Path(__file__).resolve().parents[2]
+BASE_DIR: Final[Path] = Path(__file__).resolve().parents[1]
 LOG: Final[Path] = BASE_DIR / "logs" / "test.jsonl"
 REPORT: Final[Path] = BASE_DIR / "reports" / "today.md"
 ISSUE_OUT: Final[Path] = BASE_DIR / "reports" / "issue_suggestions.md"

--- a/workflow-cookbook/tests/test_analyze_script.py
+++ b/workflow-cookbook/tests/test_analyze_script.py
@@ -27,6 +27,14 @@ def load_analyze_module() -> ModuleType:
     return module
 
 
+def test_analyze_paths_within_workflow_root() -> None:
+    analyze = load_analyze_module()
+
+    assert analyze.LOG == WORKFLOW_ROOT / "logs" / "test.jsonl"
+    assert analyze.REPORT == WORKFLOW_ROOT / "reports" / "today.md"
+    assert analyze.ISSUE_OUT == WORKFLOW_ROOT / "reports" / "issue_suggestions.md"
+
+
 def test_analyze_script_compiles() -> None:
     script_path = WORKFLOW_ROOT / "scripts" / "analyze.py"
     py_compile.compile(str(script_path), doraise=True)


### PR DESCRIPTION
## Summary
- add a regression test to confirm the analyze script writes within the workflow root tree
- update the analyze script to resolve its base directory to the workflow-cookbook folder so generated files live under it

## Testing
- pytest workflow-cookbook/tests/test_analyze_script.py

------
https://chatgpt.com/codex/tasks/task_e_68f02ddc6ef48321a098c07db557c489