### PR TITLE
Ensure reflection manifest references point to cookbook location

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,7 +4,7 @@
 最低限必要なのは次の通り：
 
 - `governance/policy.yaml`
-- `reflection.yaml`
+- `workflow-cookbook/reflection.yaml`
 - `workflow-cookbook/scripts/analyze.py`
 - `.github/workflows/test.yml`
 - `.github/workflows/reflection.yml`
@@ -24,5 +24,5 @@
 
 ## 注意
 - `CODEOWNERS` を適切なユーザー/チームに設定してください。
-- `reflection.yaml` の `analysis.max_tokens` を 0 にしているため、初日は LLM を使いません。
+- `workflow-cookbook/reflection.yaml` の `analysis.max_tokens` を 0 にしているため、初日は LLM を使いません。
   必要に応じて `engine: llm` と合わせて有効化してください。

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Day8 は「観測 → 反省 → 提案」のループを CI に組み込み、�
 Day8 を新しいリポジトリへ導入する際は、[`INSTALL.md`](INSTALL.md) の手順に従ってワークフローや初期ファイルをルートに配置してください。GitHub Actions では `test` → `reflection` → `pr_gate` の順で実行され、安全デチューンされた反省レポートを生成します。
 
 ## 使い方のヒント
-- 初期状態では `reflection.yaml` の `analysis.max_tokens` が 0 のため LLM 呼び出しは抑制されています。必要に応じて `engine` 設定と合わせて有効化してください。
+- 初期状態では `workflow-cookbook/reflection.yaml` の `analysis.max_tokens` が 0 のため LLM 呼び出しは抑制されています。必要に応じて `engine` 設定と合わせて有効化してください。
 - 生成されたレポート（`reports/` 配下）と提案を確認し、人間が修正 PR を作成する運用を前提としています。
 
 ---

--- a/workflow-cookbook/tests/test_workflows_defaults.py
+++ b/workflow-cookbook/tests/test_workflows_defaults.py
@@ -54,3 +54,10 @@ def test_workflow_defaults_run_working_directory() -> None:
     for workflow_name in ("test.yml", "reflection.yml"):
         workflow = load_workflow(workflow_name)
         assert workflow["defaults"]["run"]["working-directory"] == "workflow-cookbook"
+
+
+def test_reflection_manifest_present_for_workflow_defaults() -> None:
+    reflection_manifest = Path(__file__).resolve().parents[1] / "reflection.yaml"
+    assert (
+        reflection_manifest.exists()
+    ), "workflow-cookbook/reflection.yaml が存在する必要があります"


### PR DESCRIPTION
## Summary
- add a workflow defaults test to assert the reflection manifest lives beside the cookbook assets
- update onboarding docs to reference `workflow-cookbook/reflection.yaml`

## Testing
- pytest workflow-cookbook/tests/test_workflows_defaults.py

------
https://chatgpt.com/codex/tasks/task_e_68f02db884ec8321b38d221378c8bc69