### PR TITLE
Align analyze script paths with workflow root

### DIFF
--- a/workflow-cookbook/scripts/analyze.py
+++ b/workflow-cookbook/scripts/analyze.py
@@ -8,11 +8,9 @@ from collections import Counter
 from pathlib import Path
 from typing import Final
 
-from pathlib import Path
-
 StatusMap = dict[str, set[str]]
 
-BASE_DIR: Final[Path] = Path(__file__).resolve().parents[2]
+BASE_DIR: Final[Path] = Path(__file__).resolve().parents[1]
 LOG: Final[Path] = BASE_DIR / "logs" / "test.jsonl"
 REPORT: Final[Path] = BASE_DIR / "reports" / "today.md"
 ISSUE_OUT: Final[Path] = BASE_DIR / "reports" / "issue_suggestions.md"

--- a/workflow-cookbook/tests/test_analyze_script.py
+++ b/workflow-cookbook/tests/test_analyze_script.py
@@ -32,6 +32,14 @@ def test_analyze_script_compiles() -> None:
     py_compile.compile(str(script_path), doraise=True)
 
 
+def test_analyze_paths_use_workflow_root() -> None:
+    analyze = load_analyze_module()
+
+    assert analyze.LOG == WORKFLOW_ROOT / "logs" / "test.jsonl"
+    assert analyze.REPORT == WORKFLOW_ROOT / "reports" / "today.md"
+    assert analyze.ISSUE_OUT == WORKFLOW_ROOT / "reports" / "issue_suggestions.md"
+
+
 def test_p95_fallback_returns_max_when_quantiles_fail(monkeypatch: pytest.MonkeyPatch) -> None:
     analyze = load_analyze_module()
 


### PR DESCRIPTION
## Summary
- add coverage to ensure the analyze script keeps its log and report outputs within the workflow root
- point the analyze script's base directory at the workflow-cookbook workspace so logs and reports live there by default

## Testing
- pytest workflow-cookbook/tests/test_analyze_script.py

------
https://chatgpt.com/codex/tasks/task_e_68f02db80a48832194a54b0e255853dc