### PR TITLE
Update reflection manifest paths and add regression test

### DIFF
--- a/workflow-cookbook/reflection.yaml
+++ b/workflow-cookbook/reflection.yaml
@@ -1,6 +1,6 @@
 targets:
   - name: unit
-    logs: ["../logs/test.jsonl"]
+    logs: ["logs/test.jsonl"]
 metrics:
   - pass_rate
   - duration_p95
@@ -14,5 +14,5 @@ actions:
   open_pr_as_draft: true
   auto_fix: false         # 自動修正しない（安全デチューン）
 report:
-  output: "../reports/today.md"
+  output: "reports/today.md"
   include_why_why: true

--- a/workflow-cookbook/tests/test_reflection_layout.py
+++ b/workflow-cookbook/tests/test_reflection_layout.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import re
 from pathlib import Path
 
 
@@ -5,3 +8,30 @@ def test_reflection_manifest_present() -> None:
     project_root = Path(__file__).resolve().parents[1]
     reflection_manifest = project_root / "reflection.yaml"
     assert reflection_manifest.exists(), "workflow-cookbook/reflection.yaml が存在する必要があります"
+
+
+def test_reflection_manifest_paths() -> None:
+    project_root = Path(__file__).resolve().parents[1]
+    reflection_manifest = project_root / "reflection.yaml"
+
+    manifest_text = reflection_manifest.read_text(encoding="utf-8")
+
+    target_logs_pattern = re.compile(
+        r"targets:\s*-\s+name:\s*unit\s+logs:\s*\[\s*\"([^\"]+)\"\s*\]",
+        flags=re.MULTILINE,
+    )
+    target_logs_match = target_logs_pattern.search(manifest_text)
+    assert target_logs_match, "targets[0].logs が定義されている必要があります"
+    assert (
+        target_logs_match.group(1) == "logs/test.jsonl"
+    ), "targets[0].logs は logs/test.jsonl を指す必要があります"
+
+    report_output_pattern = re.compile(
+        r"report:\s+output:\s*\"([^\"]+)\"",
+        flags=re.MULTILINE,
+    )
+    report_output_match = report_output_pattern.search(manifest_text)
+    assert report_output_match, "report.output が定義されている必要があります"
+    assert (
+        report_output_match.group(1) == "reports/today.md"
+    ), "report.output は reports/today.md を指す必要があります"


### PR DESCRIPTION
## Summary
- add a regression test that verifies the reflection manifest uses the expected log and report paths
- update the reflection manifest to reference the logs/ and reports/ directories directly

## Testing
- pytest workflow-cookbook/tests/test_reflection_layout.py

------
https://chatgpt.com/codex/tasks/task_e_68f030589a98832190e42172fc9e9cbe