### PR TITLE
Ensure analyze script constants use workflow root

### DIFF
--- a/workflow-cookbook/scripts/analyze.py
+++ b/workflow-cookbook/scripts/analyze.py
@@ -10,10 +10,11 @@ from typing import Final
 
 StatusMap = dict[str, set[str]]
 
-BASE_DIR: Final[Path] = Path(__file__).resolve().parents[1]
-LOG: Final[Path] = BASE_DIR / "logs" / "test.jsonl"
-REPORT: Final[Path] = BASE_DIR / "reports" / "today.md"
-ISSUE_OUT: Final[Path] = BASE_DIR / "reports" / "issue_suggestions.md"
+WORKFLOW_ROOT: Final[Path] = Path(__file__).resolve().parents[1]
+BASE_DIR: Final[Path] = WORKFLOW_ROOT
+LOG: Final[Path] = WORKFLOW_ROOT / "logs" / "test.jsonl"
+REPORT: Final[Path] = WORKFLOW_ROOT / "reports" / "today.md"
+ISSUE_OUT: Final[Path] = WORKFLOW_ROOT / "reports" / "issue_suggestions.md"
 
 
 def load_results() -> tuple[list[str], list[int], list[str], StatusMap]:

--- a/workflow-cookbook/tests/test_analyze_script.py
+++ b/workflow-cookbook/tests/test_analyze_script.py
@@ -30,6 +30,7 @@ def load_analyze_module() -> ModuleType:
 def test_analyze_paths_within_workflow_root() -> None:
     analyze = load_analyze_module()
 
+    assert analyze.BASE_DIR == WORKFLOW_ROOT
     assert analyze.LOG == WORKFLOW_ROOT / "logs" / "test.jsonl"
     assert analyze.REPORT == WORKFLOW_ROOT / "reports" / "today.md"
     assert analyze.ISSUE_OUT == WORKFLOW_ROOT / "reports" / "issue_suggestions.md"


### PR DESCRIPTION
## Summary
- assert in tests that the analyze script exposes BASE_DIR at the workflow root alongside the log and report paths
- point analyze script path constants at a shared WORKFLOW_ROOT so they resolve to the repository root

## Testing
- pytest workflow-cookbook/tests/test_analyze_script.py

------
https://chatgpt.com/codex/tasks/task_e_68f03058ce5483218057b236daa94e2b