### PR TITLE
Add regression test for reflection yaml paths

### DIFF
--- a/workflow-cookbook/reflection.yaml
+++ b/workflow-cookbook/reflection.yaml
@@ -1,6 +1,7 @@
 targets:
   - name: unit
-    logs: ["logs/test.jsonl"]
+    logs:
+      - logs/test.jsonl
 metrics:
   - pass_rate
   - duration_p95
@@ -14,5 +15,5 @@ actions:
   open_pr_as_draft: true
   auto_fix: false         # 自動修正しない（安全デチューン）
 report:
-  output: "reports/today.md"
+  output: reports/today.md
   include_why_why: true

--- a/workflow-cookbook/tests/test_workflows_reflection.py
+++ b/workflow-cookbook/tests/test_workflows_reflection.py
@@ -3,6 +3,16 @@ from __future__ import annotations
 from pathlib import Path
 
 
+def test_reflection_yaml_uses_repo_relative_paths() -> None:
+    reflection_path = Path(__file__).resolve().parents[1] / "reflection.yaml"
+    content = reflection_path.read_text(encoding="utf-8")
+
+    assert "- logs/test.jsonl" in content
+    assert "../logs/test.jsonl" not in content
+    assert "output: reports/today.md" in content
+    assert "../reports/today.md" not in content
+
+
 def test_reflection_workflow_analyze_step_runs_analyze_script() -> None:
     workflow_path = (
         Path(__file__).resolve().parents[2]


### PR DESCRIPTION
## Summary
- add a regression test to ensure the reflection workflow uses repository-relative log and report paths
- normalize reflection.yaml to list the log target and report output without parent-directory segments

## Testing
- pytest workflow-cookbook/tests/test_workflows_reflection.py

------
https://chatgpt.com/codex/tasks/task_e_68f03214e7cc8321bff110fd58dd3cf0