### PR TITLE
Fix reflection workflow analyze step expected block string

### DIFF
--- a/workflow-cookbook/tests/test_workflows_reflection.py
+++ b/workflow-cookbook/tests/test_workflows_reflection.py
@@ -22,17 +22,12 @@ def test_reflection_workflow_analyze_step_runs_analyze_script() -> None:
     )
     content = workflow_path.read_text(encoding="utf-8")
 
-    expected_block = (
-        "\n".join(
-            [
-                "      - name: Analyze logs → report",
-                "        working-directory: workflow-cookbook",
-                "        run: |",
-                "          python scripts/analyze.py",
-            ]
-        )
-        + "\n"
-    )
+    expected_block = """\
+      - name: Analyze logs → report
+        working-directory: workflow-cookbook
+        run: |
+          python scripts/analyze.py
+    """.rstrip()
 
     assert expected_block in content
 


### PR DESCRIPTION
## Summary
- rewrite the expected workflow block in the reflection test as a single triple-quoted string so substring checks work without raising errors

## Testing
- pytest workflow-cookbook/tests/test_workflows_reflection.py::test_reflection_workflow_analyze_step_runs_analyze_script

------
https://chatgpt.com/codex/tasks/task_e_68f08d39c39883218bfbf48398b96221