### PR TITLE
Fix analyze report timestamp timezone awareness

### DIFF
--- a/workflow-cookbook/scripts/analyze.py
+++ b/workflow-cookbook/scripts/analyze.py
@@ -71,7 +71,7 @@ def main() -> None:
     else:
         flaky_rate = flaky_tests / unique_tests
     dur_p95 = p95(durs)
-    now = datetime.datetime.utcnow().isoformat()
+    now = datetime.datetime.now(datetime.UTC).isoformat()
 
     REPORT.parent.mkdir(parents=True, exist_ok=True)
     with REPORT.open("w", encoding="utf-8") as f:

--- a/workflow-cookbook/tests/test_analyze_script.py
+++ b/workflow-cookbook/tests/test_analyze_script.py
@@ -115,6 +115,22 @@ def test_main_reports_zero_when_no_log(
     assert "Pass rate:" in contents and "100.00%" not in contents
 
 
+def test_main_timestamp_is_timezone_aware(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    analyze = load_analyze_module()
+
+    report_path = tmp_path / "reports" / "today.md"
+    monkeypatch.setattr(analyze, "LOG", tmp_path / "missing.jsonl")
+    monkeypatch.setattr(analyze, "REPORT", report_path)
+
+    analyze.main()
+
+    header = report_path.read_text(encoding="utf-8").splitlines()[0]
+
+    assert "+00:00 UTC" in header
+
+
 def test_main_reports_zero_when_log_empty(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- add regression test ensuring the reflection report timestamp includes an explicit UTC offset
- switch analyze.py to generate timestamps with datetime.now(datetime.UTC)

## Testing
- pytest workflow-cookbook/tests/test_analyze_script.py workflow-cookbook/tests/test_workflows_reflection.py

------
https://chatgpt.com/codex/tasks/task_e_68f002dc4a5483218e2fbb466a0cee71