### PR TITLE
Update reflection layout test to validate report output path

### DIFF
--- a/workflow-cookbook/tests/test_reflection_layout.py
+++ b/workflow-cookbook/tests/test_reflection_layout.py
@@ -1,8 +1,64 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import IO, Any, Dict, List
 
-import re
+try:
+    import yaml  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback for test envs without PyYAML
+    class _MiniYAML:
+        def safe_load(self, stream: IO[str] | str) -> Dict[str, Any]:
+            if hasattr(stream, "read"):
+                content = stream.read()
+            else:
+                content = str(stream)
+
+            root: Dict[str, Any] = {}
+            stack: list[Dict[str, Any]] = [root]
+            indents = [0]
+
+            for raw_line in content.splitlines():
+                stripped = raw_line.lstrip()
+                if not stripped or stripped.startswith("#"):
+                    continue
+
+                indent = len(raw_line) - len(stripped)
+                key, _, value = stripped.partition(":")
+                value = value.strip()
+
+                while indent < indents[-1]:
+                    stack.pop()
+                    indents.pop()
+
+                if value == "":
+                    new_map: Dict[str, Any] = {}
+                    stack[-1][key] = new_map
+                    stack.append(new_map)
+                    indents.append(indent + 2)
+                else:
+                    if value.startswith("[") and value.endswith("]"):
+                        items = []
+                        raw_items = value[1:-1].split(",") if value[1:-1].strip() else []
+                        for raw_item in raw_items:
+                            items.append(raw_item.strip().strip('"\''))
+                        stack[-1][key] = items
+                    else:
+                        stack[-1][key] = value.strip('"\'')
+
+            return root
+
+    yaml = _MiniYAML()  # type: ignore
+
+
+def _coerce_targets(raw_targets: Any) -> List[Dict[str, Any]]:
+    if isinstance(raw_targets, dict):
+        converted_target: Dict[str, Any] = {}
+        if "- name" in raw_targets:
+            converted_target["name"] = raw_targets["- name"]
+        if "logs" in raw_targets:
+            converted_target["logs"] = raw_targets["logs"]
+        return [converted_target]
+    return raw_targets
 
 
 def test_reflection_manifest_present() -> None:
@@ -15,31 +71,12 @@ def test_reflection_manifest_paths() -> None:
     project_root = Path(__file__).resolve().parents[1]
     reflection_manifest = project_root / "reflection.yaml"
 
-    manifest_text = reflection_manifest.read_text(encoding="utf-8")
+    manifest = yaml.safe_load(reflection_manifest.read_text(encoding="utf-8"))
 
-    target_logs_pattern = re.compile(
-        r"targets:\s*-.*?name:\s*unit.*?logs:\s*(?:\[\s*\"(?P<inline>[^\"]+)\"\s*\]|(?P<block>(?:\n\s*-\s*[\"']?[^\n]+)+))",
-        flags=re.DOTALL,
-    )
-    target_logs_match = target_logs_pattern.search(manifest_text)
-    assert target_logs_match, "unit ターゲットの logs が定義されている必要があります"
+    targets = _coerce_targets(manifest["targets"])
+    assert targets[0]["logs"] == ["logs/test.jsonl"], "targets[0].logs は logs/test.jsonl を指す必要があります"
 
-    logs_value: str | None = target_logs_match.group("inline")
-    if logs_value is None:
-        block = target_logs_match.group("block")
-        assert block is not None, "logs ブロックが取得できません"
-        block_match = re.search(r"-\s*[\"']?([^\s\"']+)", block)
-        assert block_match, "logs 配列に要素が必要です"
-        logs_value = block_match.group(1)
-
-    assert logs_value == "logs/test.jsonl", "targets[0].logs は logs/test.jsonl を指す必要があります"
-
-    report_output_pattern = re.compile(
-        r"report:\s+.*?output:\s*\"?([^\s\"']+)\"?",
-        flags=re.DOTALL,
-    )
-    report_output_match = report_output_pattern.search(manifest_text)
-    assert report_output_match, "report.output が定義されている必要があります"
-    assert (
-        report_output_match.group(1) == "reports/today.md"
-    ), "report.output は reports/today.md を指す必要があります"
+    report = manifest["report"]
+    output = report["output"]
+    assert output == "reports/today.md", "report.output は reports/today.md を指す必要があります"
+    assert not output.startswith("../"), "report.output で相対パス逸脱を許可しません"


### PR DESCRIPTION
## Summary
- load workflow-cookbook/reflection.yaml via YAML parsing during layout tests
- ensure report output stays on reports/today.md and does not escape via ../ prefix
- reuse target log assertion without relying on brittle string matching

## Testing
- pytest workflow-cookbook/tests/test_reflection_layout.py

------
https://chatgpt.com/codex/tasks/task_e_68f0d31abeb08321a6b0f7c1285e08a2