### PR TITLE
Fix workflow defaults test unused import warning

### DIFF
--- a/workflow-cookbook/tests/test_workflows_defaults.py
+++ b/workflow-cookbook/tests/test_workflows_defaults.py
@@ -93,8 +93,8 @@ def test_reflection_manifest_logs_entry() -> None:
             converted_target["name"] = raw_targets["- name"]
         if "logs" in raw_targets:
             converted_target["logs"] = raw_targets["logs"]
-        targets = [converted_target]
+        targets: list[Dict[str, Any]] = [converted_target]
     else:
-        targets = raw_targets
+        targets = cast(list[Dict[str, Any]], raw_targets)
 
     assert targets[0]["logs"] == ["logs/test.jsonl"]


### PR DESCRIPTION
## Summary
- ensure the targets variable in the workflow defaults test is explicitly typed so that the `cast` import is used

## Testing
- ruff check workflow-cookbook/tests/test_workflows_defaults.py

------
https://chatgpt.com/codex/tasks/task_e_68f0fc5591948321b2ed602bb79fc674