### PR TITLE
Add failure counts to Why-Why report entries

### DIFF
--- a/workflow-cookbook/scripts/analyze.py
+++ b/workflow-cookbook/scripts/analyze.py
@@ -85,7 +85,7 @@ def main() -> None:
             f.write("## Why-Why (draft)\n")
             for name, cnt in Counter(fails).items():
                 f.write(
-                    f"- {name}: 仮説=前処理の不安定/依存の競合/境界値不足\n"
+                    f"- {name} (x{cnt}): 仮説=前処理の不安定/依存の競合/境界値不足\n"
                 )
 
     # Issue候補のメモ（Actionsで拾ってIssue化）

--- a/workflow-cookbook/tests/test_analyze_script.py
+++ b/workflow-cookbook/tests/test_analyze_script.py
@@ -210,6 +210,9 @@ def test_main_records_issue_todos_for_failures(
 
     analyze.main()
 
+    report_contents = report_path.read_text(encoding="utf-8").splitlines()
+    assert "- sample::fail (x2): 仮説=前処理の不安定/依存の競合/境界値不足" in report_contents
+
     contents = issue_path.read_text(encoding="utf-8").splitlines()
 
     assert (


### PR DESCRIPTION
## Summary
- extend the analyze script to include failure occurrence counts in the Why-Why draft section
- update the analyze script tests to assert the formatted Why-Why entries with counts

## Testing
- pytest workflow-cookbook/tests/test_analyze_script.py
- ruff check workflow-cookbook/scripts/analyze.py

------
https://chatgpt.com/codex/tasks/task_e_68f0fc54dec8832191fde03822fac75a