### PR TITLE
Handle empty quoted front matter owners

### DIFF
--- a/workflow-cookbook/tests/test_check_front_matter.py
+++ b/workflow-cookbook/tests/test_check_front_matter.py
@@ -88,6 +88,26 @@ def test_validate_markdown_front_matter_owner_hash_not_missing(
     assert repo_root / "README.md" not in missing
 
 
+@pytest.mark.parametrize("owner_value", ['""', "''"])
+def test_validate_markdown_front_matter_owner_empty_is_missing(
+    repo_root: Path, owner_value: str
+) -> None:
+    _write_markdown(
+        repo_root / "README.md",
+        (
+            ("intent_id", "INT-126"),
+            ("owner", owner_value),
+            ("status", "active"),
+            ("last_reviewed_at", "2024-01-04"),
+            ("next_review_due", "2024-02-04"),
+        ),
+    )
+
+    missing = validate_markdown_front_matter(repo_root)
+
+    assert missing == {repo_root / "README.md": ["owner"]}
+
+
 def test_validate_markdown_front_matter_missing_fields(repo_root: Path) -> None:
     _write_markdown(
         repo_root / "README.md",

--- a/workflow-cookbook/tools/ci/check_front_matter.py
+++ b/workflow-cookbook/tools/ci/check_front_matter.py
@@ -65,6 +65,8 @@ def _parse_fields(front_matter_lines: Iterable[str]) -> Dict[str, str]:
             continue
         key, value = stripped.split(":", 1)
         value = _strip_inline_comment(value.strip())
+        if value in {"''", '""'}:
+            value = ""
         data[key.strip()] = value
     return data
 


### PR DESCRIPTION
## Summary
- add regression coverage to ensure quoted-empty owner values are treated as missing
- normalize quoted empty strings to empty values during front matter parsing so validators catch them

## Testing
- pytest tests/test_check_front_matter.py -q

------
https://chatgpt.com/codex/tasks/task_e_68f12256fbc883219384baa1d31d6cfb