### PR TITLE
Normalize quoted empty front matter values

### DIFF
--- a/workflow-cookbook/tests/test_check_front_matter.py
+++ b/workflow-cookbook/tests/test_check_front_matter.py
@@ -108,6 +108,26 @@ def test_validate_markdown_front_matter_owner_empty_is_missing(
     assert missing == {repo_root / "README.md": ["owner"]}
 
 
+@pytest.mark.parametrize("owner_value", ['"   "', '"\t"'])
+def test_validate_markdown_front_matter_owner_whitespace_is_missing(
+    repo_root: Path, owner_value: str
+) -> None:
+    _write_markdown(
+        repo_root / "README.md",
+        (
+            ("intent_id", "INT-127"),
+            ("owner", owner_value),
+            ("status", "active"),
+            ("last_reviewed_at", "2024-01-06"),
+            ("next_review_due", "2024-02-06"),
+        ),
+    )
+
+    missing = validate_markdown_front_matter(repo_root)
+
+    assert missing == {repo_root / "README.md": ["owner"]}
+
+
 def test_validate_markdown_front_matter_missing_fields(repo_root: Path) -> None:
     _write_markdown(
         repo_root / "README.md",

--- a/workflow-cookbook/tools/ci/check_front_matter.py
+++ b/workflow-cookbook/tools/ci/check_front_matter.py
@@ -67,6 +67,13 @@ def _parse_fields(front_matter_lines: Iterable[str]) -> Dict[str, str]:
         value = _strip_inline_comment(value.strip())
         if value in {"''", '""'}:
             value = ""
+        elif (
+            len(value) >= 2
+            and value[0] == value[-1]
+            and value[0] in {"'", '"'}
+            and value[1:-1].strip() == ""
+        ):
+            value = ""
         data[key.strip()] = value
     return data
 


### PR DESCRIPTION
## Summary
- add regression coverage for owners specified as quoted empty or whitespace-only values
- treat quoted whitespace-only front matter entries as empty so required-field checks flag them
- ensure existing hash-prefixed owner values continue to be preserved

## Testing
- pytest workflow-cookbook/tests/test_check_front_matter.py

------
https://chatgpt.com/codex/tasks/task_e_68f1248230cc8321a07f26fb2d533e20