### PR TITLE
Handle bold priority score formatting

### DIFF
--- a/workflow-cookbook/tests/test_check_governance_gate.py
+++ b/workflow-cookbook/tests/test_check_governance_gate.py
@@ -181,6 +181,7 @@ def test_validate_priority_score(body, expected, message):
         "- [ ] Priority Score: 4 / 未チェック",
         "- [x] Priority Score: 8 / チェック済み",
         "1. Priority Score: 7 / 番号付きリスト",
+        "**Priority Score:** 5 / 強調付き",
     ],
 )
 def test_validate_priority_score_valid(body):

--- a/workflow-cookbook/tools/ci/check_governance_gate.py
+++ b/workflow-cookbook/tools/ci/check_governance_gate.py
@@ -11,6 +11,8 @@ from pathlib import Path, PurePosixPath
 from typing import Iterable, List, Sequence
 
 
+MARKDOWN_STRONG_PATTERN = re.compile(r"(?:\*\*|__)(.+?)(?:\*\*|__)")
+
 BULLET_PATTERN = re.compile(r"^\s*(?:[-*+]\s*(?:\[[xX ]\])?\s*|\d+[.)]\s*)")
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -211,7 +213,8 @@ def validate_priority_score(body: str | None) -> tuple[bool, str | None]:
         return False, "Priority Score セクションが見つかりません"
 
     normalized_body = "\n".join(
-        BULLET_PATTERN.sub("", line).lstrip() for line in body.splitlines()
+        BULLET_PATTERN.sub("", MARKDOWN_STRONG_PATTERN.sub(r"\1", line)).lstrip()
+        for line in body.splitlines()
     )
     pattern = re.compile(r"^Priority Score:\s*(?P<content>.+)$", re.MULTILINE)
     match = pattern.search(normalized_body)


### PR DESCRIPTION
## Summary
- add a regression test covering bold Priority Score formatting in pull request bodies
- strip Markdown strong emphasis markers before validating Priority Score lines

## Testing
- `pytest workflow-cookbook/tests/test_check_governance_gate.py`


------
https://chatgpt.com/codex/tasks/task_e_68f1248256c883219a131d1eb650b586