### PR TITLE
Normalize Priority Score validation for colon variants

### DIFF
--- a/workflow-cookbook/tests/test_check_governance_gate.py
+++ b/workflow-cookbook/tests/test_check_governance_gate.py
@@ -182,6 +182,8 @@ def test_validate_priority_score(body, expected, message):
         "- [x] Priority Score: 8 / チェック済み",
         "1. Priority Score: 7 / 番号付きリスト",
         "**Priority Score:** 5 / 強調付き",
+        "Priority Score : 5 / 理由",
+        "Priority Score：5 / 理由",
     ],
 )
 def test_validate_priority_score_valid(body):

--- a/workflow-cookbook/tools/ci/check_governance_gate.py
+++ b/workflow-cookbook/tools/ci/check_governance_gate.py
@@ -216,6 +216,12 @@ def validate_priority_score(body: str | None) -> tuple[bool, str | None]:
         BULLET_PATTERN.sub("", MARKDOWN_STRONG_PATTERN.sub(r"\1", line)).lstrip()
         for line in body.splitlines()
     )
+    normalized_body = re.sub(
+        r"(Priority Score)\s*[：:]",
+        r"\1:",
+        normalized_body,
+        flags=re.MULTILINE,
+    )
     pattern = re.compile(r"^Priority Score:\s*(?P<content>.+)$", re.MULTILINE)
     match = pattern.search(normalized_body)
     if not match:


### PR DESCRIPTION
## Summary
- add regression coverage for Priority Score entries that use spacing or full-width colons
- normalize Priority Score lines before validation to handle colon variants consistently

## Testing
- pytest workflow-cookbook/tests/test_check_governance_gate.py

------
https://chatgpt.com/codex/tasks/task_e_68f15b7955548321b7ea2b4e3c422979