### PR TITLE
Adjust reflection issue step hash guard

### DIFF
--- a/.github/workflows/reflection.yml
+++ b/.github/workflows/reflection.yml
@@ -52,7 +52,7 @@ jobs:
           git commit -m "chore(report): reflection report [skip ci]" || echo "no changes"
           git push || true
       - name: Open issue if needed (draft memo)
-        if: ${{ hashFiles('workflow-cookbook/reports/issue_suggestions.md') != '' }}
+        if: ${{ hashFiles('workflow-cookbook/reports/issue_suggestions.md') != '0' }}
         uses: peter-evans/create-issue-from-file@v5
         with:
           title: "反省TODO ${{ github.run_id }}"

--- a/workflow-cookbook/tests/test_workflows_reflection.py
+++ b/workflow-cookbook/tests/test_workflows_reflection.py
@@ -76,3 +76,19 @@ def test_reflection_workflow_download_step_warns_when_artifact_missing() -> None
     expected_line = "          if-no-artifact-found: warn\n"
 
     assert expected_line in content
+
+
+def test_reflection_workflow_issue_step_skips_when_file_missing() -> None:
+    workflow_path = (
+        Path(__file__).resolve().parents[2]
+        / ".github"
+        / "workflows"
+        / "reflection.yml"
+    )
+    content = workflow_path.read_text(encoding="utf-8")
+
+    expected_condition = (
+        "        if: ${{ hashFiles('workflow-cookbook/reports/issue_suggestions.md') != '0' }}\n"
+    )
+
+    assert expected_condition in content


### PR DESCRIPTION
## Summary
- add a regression test to ensure the reflection workflow skips the issue step when the suggestions file is absent
- update the reflection workflow condition so hashFiles returning '0' prevents the issue step from running

## Testing
- pytest workflow-cookbook/tests/test_workflows_reflection.py

------
https://chatgpt.com/codex/tasks/task_e_68f1625fa3e88321969b746a06672ee8