### PR TITLE
Add guard for reflection issue creation condition

### DIFF
--- a/.github/workflows/reflection.yml
+++ b/.github/workflows/reflection.yml
@@ -52,6 +52,7 @@ jobs:
           git commit -m "chore(report): reflection report [skip ci]" || echo "no changes"
           git push || true
       - name: Open issue if needed (draft memo)
+        # Skip issue creation when no suggestions were produced.
         if: ${{ hashFiles('workflow-cookbook/reports/issue_suggestions.md') != '0' }}
         uses: peter-evans/create-issue-from-file@v5
         with:

--- a/workflow-cookbook/tests/test_workflows_reflection.py
+++ b/workflow-cookbook/tests/test_workflows_reflection.py
@@ -92,3 +92,17 @@ def test_reflection_workflow_issue_step_skips_when_file_missing() -> None:
     )
 
     assert expected_condition in content
+
+
+def test_reflection_workflow_issue_step_condition_checks_hashfiles_zero() -> None:
+    workflow_path = (
+        Path(__file__).resolve().parents[2]
+        / ".github"
+        / "workflows"
+        / "reflection.yml"
+    )
+    content = workflow_path.read_text(encoding="utf-8")
+    condition_snippet = "hashFiles('workflow-cookbook/reports/issue_suggestions.md')"
+
+    assert f"{condition_snippet} != '0'" in content
+    assert f"{condition_snippet} != ''" not in content


### PR DESCRIPTION
## Summary
- add a regression test that ensures the reflection workflow only opens an issue when hashFiles returns a non-zero value
- document the issue-creation step in the workflow to clarify why the hashFiles zero guard is required

## Testing
- pytest workflow-cookbook/tests/test_workflows_reflection.py

------
https://chatgpt.com/codex/tasks/task_e_68f16938fbfc8321b708a440c14a358e