### PR TITLE
feat: respect reflection manifest issue suggestion flag

### DIFF
--- a/workflow-cookbook/tests/test_analyze_script.py
+++ b/workflow-cookbook/tests/test_analyze_script.py
@@ -284,3 +284,37 @@ def test_main_skips_issue_notes_when_suggestions_disabled(
     analyze.main()
 
     assert not issue_path.exists()
+
+
+def test_main_uses_reflection_manifest_to_skip_issue_suggestions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    analyze = load_analyze_module()
+
+    log_path = tmp_path / "logs" / "failures.jsonl"
+    log_path.parent.mkdir(parents=True)
+    log_path.write_text(
+        json.dumps({"name": "disabled::fail", "status": "fail", "duration_ms": 15})
+        + "\n",
+        encoding="utf-8",
+    )
+
+    reflection_path = tmp_path / "reflection.yaml"
+    reflection_path.write_text("actions:\n  suggest_issues: false\n", encoding="utf-8")
+
+    manifest = analyze.load_reflection_manifest(reflection_path)
+    assert manifest.get("actions", {}).get("suggest_issues") is False
+
+    issue_path = tmp_path / "reports" / "issue_suggestions.md"
+
+    for attr, value in {
+        "LOG": log_path,
+        "REPORT": tmp_path / "reports" / "today.md",
+        "ISSUE_OUT": issue_path,
+        "REFLECTION_MANIFEST": reflection_path,
+    }.items():
+        monkeypatch.setattr(analyze, attr, value)
+
+    analyze.main()
+
+    assert not issue_path.exists()


### PR DESCRIPTION
## Summary
- add a helper that reads the reflection manifest and exposes the actions settings
- reuse the manifest data in the analyze script so issue drafts are skipped when suggest_issues is false
- extend the analyze script tests to cover manifest-driven skips for issue drafts

## Testing
- pytest workflow-cookbook/tests/test_analyze_script.py

------
https://chatgpt.com/codex/tasks/task_e_68f16e99174c8321a8a1b5482bb0bf43