### PR TITLE
Respect custom report output path

### DIFF
--- a/workflow-cookbook/scripts/analyze.py
+++ b/workflow-cookbook/scripts/analyze.py
@@ -175,14 +175,19 @@ def load_report_output_path(
     path: Path | None = None,
     *,
     default: Path | None = None,
+    manifest: dict[str, Any] | None = None,
 ) -> Path:
-    manifest = load_reflection_manifest(
-        path,
-        default_suggest_issues=True,
-        default_include_why=True,
+    manifest_data = (
+        load_reflection_manifest(
+            path,
+            default_suggest_issues=True,
+            default_include_why=True,
+        )
+        if manifest is None
+        else manifest
     )
     fallback = default or REPORT
-    report_section: Any = manifest.get("report") if manifest else None
+    report_section: Any = manifest_data.get("report") if manifest_data else None
     candidate: object = report_section.get("output") if isinstance(report_section, dict) else None
     candidate_path: Path | None = None
     if isinstance(candidate, Path):
@@ -257,8 +262,9 @@ def main() -> None:
     dur_p95 = p95(durs)
     now = datetime.datetime.now(datetime.UTC).isoformat()
 
-    report_path = load_report_output_path()
-    include_why = load_report_include_why()
+    manifest = load_reflection_manifest()
+    report_path = load_report_output_path(manifest=manifest)
+    include_why = load_report_include_why(manifest=manifest)
 
     report_path.parent.mkdir(parents=True, exist_ok=True)
     with report_path.open("w", encoding="utf-8") as f:
@@ -277,14 +283,23 @@ def main() -> None:
 
     # Issue候補のメモ（Actionsで拾ってIssue化）
     suggest_issues = load_actions_suggest_issues(manifest=manifest)
+    issue_output_path = ISSUE_OUT
+    if not issue_output_path.is_absolute():
+        issue_output_path = BASE_DIR / issue_output_path
+    if (
+        issue_output_path.parent == DEFAULT_REPORT.parent
+        and report_path.parent != DEFAULT_REPORT.parent
+    ):
+        issue_output_path = report_path.parent / issue_output_path.name
     if fails and suggest_issues:
-        with ISSUE_OUT.open("w", encoding="utf-8") as f:
+        issue_output_path.parent.mkdir(parents=True, exist_ok=True)
+        with issue_output_path.open("w", encoding="utf-8") as f:
             f.write("### 反省TODO\n")
             for name in sorted(set(fails)):
                 f.write(f"- [ ] {name} の再現手順/前提/境界値を追加\n")
                 f.write(f"- [ ] {name} の再現手順/前提/境界値の工程を増やす\n")
-    elif ISSUE_OUT.exists():
-        ISSUE_OUT.unlink()
+    elif issue_output_path.exists():
+        issue_output_path.unlink()
 
 
 if __name__ == "__main__":

--- a/workflow-cookbook/tests/test_analyze_script.py
+++ b/workflow-cookbook/tests/test_analyze_script.py
@@ -421,6 +421,42 @@ def test_main_writes_report_to_custom_manifest_output(
     assert "Total tests: 0" in contents
 
 
+def test_main_prefers_manifest_output_over_report_constant(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    analyze = load_analyze_module()
+
+    log_path = tmp_path / "logs" / "failures.jsonl"
+    log_path.parent.mkdir(parents=True)
+    log_path.write_text(
+        json.dumps({"name": "case::fail", "status": "fail", "duration_ms": 12})
+        + "\n",
+        encoding="utf-8",
+    )
+
+    reflection_path = tmp_path / "reflection.yaml"
+    reflection_path.write_text(
+        "report:\n  output: reports/custom.md\n",
+        encoding="utf-8",
+    )
+
+    default_report = tmp_path / "reports" / "today.md"
+
+    for attr, value in {
+        "LOG": log_path,
+        "REPORT": default_report,
+        "ISSUE_OUT": tmp_path / "reports" / "issue_suggestions.md",
+        "REFLECTION_MANIFEST": reflection_path,
+        "BASE_DIR": tmp_path,
+    }.items():
+        monkeypatch.setattr(analyze, attr, value)
+
+    analyze.main()
+
+    custom_report = tmp_path / "reports" / "custom.md"
+    assert custom_report.exists()
+    assert not default_report.exists()
+
 def test_main_skips_why_why_section_when_disabled(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- add coverage ensuring the analyze script respects report.output from the reflection manifest
- reuse the loaded manifest to select report and issue destinations, honoring custom paths

## Testing
- pytest workflow-cookbook/tests/test_analyze_script.py -q

------
https://chatgpt.com/codex/tasks/task_e_68f1cf7012548321a6f41c7ef4e0ad09