### PR TITLE
fix: tolerate missing reflection artifacts

### DIFF
--- a/.github/workflows/reflection.yml
+++ b/.github/workflows/reflection.yml
@@ -29,12 +29,16 @@ jobs:
           RUN_ID: ${{ github.event.workflow_run.id || '' }}
       - name: Download test logs
         if: ${{ steps.artifact-meta.outputs.run_id != '' }}
+        id: download-logs
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: test-logs
           path: workflow-cookbook/logs
           run-id: ${{ steps.artifact-meta.outputs.run_id }}
-          if-no-artifact-found: warn
+      - name: Notice missing logs
+        if: ${{ steps.download-logs.outcome == 'failure' }}
+        run: echo "::notice title=artifact::test-logs artifact not found; continuing"
       - name: Setup Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary
- allow the reflection workflow to continue when the test-logs artifact is missing
- emit a workflow notice if the artifact cannot be downloaded

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f1f9d047f483219ee3649311dea882