### PR TITLE
fix: remove unsupported download-artifact input

### DIFF
--- a/.github/workflows/reflection.yml
+++ b/.github/workflows/reflection.yml
@@ -67,7 +67,6 @@ jobs:
           name: test-logs
           path: workflow-cookbook/logs
           run-id: ${{ steps.artifact-meta.outputs.run_id }}
-          if-no-artifact-found: warn
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/workflow-cookbook/tests/test_workflows_reflection.py
+++ b/workflow-cookbook/tests/test_workflows_reflection.py
@@ -78,10 +78,11 @@ def test_reflection_workflow_download_step_warns_when_artifact_missing() -> None
     content = workflow_path.read_text(encoding="utf-8")
 
     expected_version_line = "        uses: actions/download-artifact@v4.1.7\n"
-    expected_behavior_line = "          if-no-artifact-found: warn\n"
+    fallback_notice = "core.notice(`test-logs artifact not found for run ${runId}; skipping download`);\n"
 
     assert expected_version_line in content
-    assert expected_behavior_line in content
+    assert fallback_notice in content
+    assert "if-no-artifact-found" not in content
 
 
 def test_reflection_workflow_issue_step_skips_when_file_missing() -> None:


### PR DESCRIPTION
## Summary
- adjust the reflection workflow to rely on the locator notice instead of the unsupported `if-no-artifact-found` input
- update the reflection workflow test to assert the GitHub Script notice and the absence of the unsupported input

## Testing
- pytest workflow-cookbook/tests/test_workflows_reflection.py

------
https://chatgpt.com/codex/tasks/task_e_68f203960e38832186b5f6d99418b9df