### PR TITLE
Fix reflection workflow artifact download

### DIFF
--- a/.github/workflows/reflection.yml
+++ b/.github/workflows/reflection.yml
@@ -64,6 +64,7 @@ jobs:
         id: download-logs
         uses: actions/download-artifact@v4.1.7
         with:
+          artifact-id: ${{ steps.artifact-locator.outputs.artifact-id }}
           name: test-logs
           path: workflow-cookbook/logs
           run-id: ${{ steps.artifact-meta.outputs.run_id }}

--- a/workflow-cookbook/tests/test_workflows_reflection.py
+++ b/workflow-cookbook/tests/test_workflows_reflection.py
@@ -79,9 +79,13 @@ def test_reflection_workflow_download_step_warns_when_artifact_missing() -> None
 
     expected_version_line = "        uses: actions/download-artifact@v4.1.7\n"
     fallback_notice = "core.notice(`test-logs artifact not found for run ${runId}; skipping download`);\n"
+    artifact_id_reference = (
+        "          artifact-id: ${{ steps.artifact-locator.outputs.artifact-id }}\n"
+    )
 
     assert expected_version_line in content
     assert fallback_notice in content
+    assert artifact_id_reference in content
     assert "if-no-artifact-found" not in content
 
 


### PR DESCRIPTION
## Summary
- ensure the reflection workflow passes the artifact id to actions/download-artifact
- extend the reflection workflow tests to assert the artifact id is wired through

## Testing
- pytest tests/test_workflows_reflection.py

------
https://chatgpt.com/codex/tasks/task_e_68f20936449883219e9b6ba36d2a8745