### PR TITLE
Fix reflection workflow artifact download input

### DIFF
--- a/.github/workflows/reflection.yml
+++ b/.github/workflows/reflection.yml
@@ -64,7 +64,6 @@ jobs:
         id: download-logs
         uses: actions/download-artifact@v4.1.7
         with:
-          artifact-id: ${{ steps.artifact-locator.outputs.artifact-id }}
           name: test-logs
           path: workflow-cookbook/logs
           run-id: ${{ steps.artifact-meta.outputs.run_id }}

--- a/workflow-cookbook/tests/test_workflows_reflection.py
+++ b/workflow-cookbook/tests/test_workflows_reflection.py
@@ -79,13 +79,15 @@ def test_reflection_workflow_download_step_warns_when_artifact_missing() -> None
 
     expected_version_line = "        uses: actions/download-artifact@v4.1.7\n"
     fallback_notice = "core.notice(`test-logs artifact not found for run ${runId}; skipping download`);\n"
-    artifact_id_reference = (
+    download_name_line = "          name: test-logs\n"
+    unexpected_artifact_id_reference = (
         "          artifact-id: ${{ steps.artifact-locator.outputs.artifact-id }}\n"
     )
 
     assert expected_version_line in content
     assert fallback_notice in content
-    assert artifact_id_reference in content
+    assert download_name_line in content
+    assert unexpected_artifact_id_reference not in content
     assert "if-no-artifact-found" not in content
 
 


### PR DESCRIPTION
## Summary
- remove the unsupported `artifact-id` input from the reflection workflow download step
- update the reflection workflow test to assert the new download configuration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f20b1da39883219d610fd823bf0a00