### PR TITLE
Handle cross-repo artifact downloads gracefully

### DIFF
--- a/.github/workflows/reflection.yml
+++ b/.github/workflows/reflection.yml
@@ -23,11 +23,17 @@ jobs:
         run: |
           if [ -n "${RUN_ID}" ]; then
             echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
+            if [ -n "${RUN_REPOSITORY}" ]; then
+              echo "run_repository=$RUN_REPOSITORY" >> "$GITHUB_OUTPUT"
+            else
+              echo "run_repository=$GITHUB_REPOSITORY" >> "$GITHUB_OUTPUT"
+            fi
           else
             echo "::notice title=artifact::No linked workflow_run; skip download"
           fi
         env:
           RUN_ID: ${{ github.event.workflow_run.id || '' }}
+          RUN_REPOSITORY: ${{ github.event.workflow_run.repository.full_name || '' }}
       - name: Locate test logs artifact
         if: ${{ steps.artifact-meta.outputs.run_id != '' }}
         id: artifact-locator
@@ -35,7 +41,15 @@ jobs:
         with:
           script: |
             const runId = Number(process.env.RUN_ID);
+            const repository = process.env.RUN_REPOSITORY ?? '';
+            const current = `${context.repo.owner}/${context.repo.repo}`;
             if (!Number.isFinite(runId) || runId <= 0) {
+              core.setOutput('artifact-id', '');
+              core.setOutput('found', 'false');
+              return;
+            }
+            if (repository && repository !== current) {
+              core.notice(`run ${runId} belongs to ${repository}; cross-repo artifacts require a PAT with actions:read permissions.`);
               core.setOutput('artifact-id', '');
               core.setOutput('found', 'false');
               return;
@@ -59,6 +73,7 @@ jobs:
             core.setOutput('found', 'true');
         env:
           RUN_ID: ${{ steps.artifact-meta.outputs.run_id }}
+          RUN_REPOSITORY: ${{ steps.artifact-meta.outputs.run_repository || github.repository }}
       - name: Download test logs
         if: ${{ steps.artifact-locator.outputs.found == 'true' }}
         id: download-logs

--- a/workflow-cookbook/tests/test_workflows_reflection.py
+++ b/workflow-cookbook/tests/test_workflows_reflection.py
@@ -79,6 +79,9 @@ def test_reflection_workflow_download_step_warns_when_artifact_missing() -> None
 
     expected_version_line = "        uses: actions/download-artifact@v4.1.7\n"
     fallback_notice = "core.notice(`test-logs artifact not found for run ${runId}; skipping download`);\n"
+    cross_repo_notice = (
+        "              core.notice(`run ${runId} belongs to ${repository}; cross-repo artifacts require a PAT with actions:read permissions.`);\n"
+    )
     download_name_line = "          name: test-logs\n"
     unexpected_artifact_id_reference = (
         "          artifact-id: ${{ steps.artifact-locator.outputs.artifact-id }}\n"
@@ -86,6 +89,7 @@ def test_reflection_workflow_download_step_warns_when_artifact_missing() -> None
 
     assert expected_version_line in content
     assert fallback_notice in content
+    assert cross_repo_notice in content
     assert download_name_line in content
     assert unexpected_artifact_id_reference not in content
     assert "if-no-artifact-found" not in content


### PR DESCRIPTION
## Summary
- capture the workflow_run repository and skip artifact downloads when it differs from the current repo
- add a GitHub Script notice explaining that cross-repo artifacts require a PAT with actions:read
- extend the reflection workflow test to assert the new guidance is present

## Testing
- pytest workflow-cookbook/tests/test_workflows_reflection.py

------
https://chatgpt.com/codex/tasks/task_e_68f20f1c2b508321b8481e766820d57e