### PR TITLE
Ensure governance gate enforces Priority Score justification

### DIFF
--- a/workflow-cookbook/tests/test_check_governance_gate.py
+++ b/workflow-cookbook/tests/test_check_governance_gate.py
@@ -114,7 +114,32 @@ Priority Score: 3
 
     assert validate_pr_body(body) is False
     captured = capsys.readouterr()
-    assert "Priority Score must include justification" in captured.err
+    assert "Priority Score must be provided as '<number> / <justification>'" in captured.err
+
+
+def test_validate_pr_body_reports_missing_priority_score(capsys):
+    body = """
+Intent: INT-314
+## EVALUATION
+- [Acceptance Criteria](../EVALUATION.md#acceptance-criteria)
+"""
+
+    assert validate_pr_body(body) is False
+    captured = capsys.readouterr()
+    assert "Priority Score must be provided as '<number> / <justification>'" in captured.err
+
+
+def test_validate_pr_body_reports_missing_priority_justification(capsys):
+    body = """
+Intent: INT-271
+## EVALUATION
+- [Acceptance Criteria](../EVALUATION.md#acceptance-criteria)
+Priority Score: 4
+"""
+
+    assert validate_pr_body(body) is False
+    captured = capsys.readouterr()
+    assert "Priority Score must be provided as '<number> / <justification>'" in captured.err
 
 
 def test_validate_pr_body_missing_intent(capsys):

--- a/workflow-cookbook/tools/ci/check_governance_gate.py
+++ b/workflow-cookbook/tools/ci/check_governance_gate.py
@@ -188,9 +188,15 @@ def validate_pr_body(body: str | None) -> bool:
     if not has_evaluation_heading or not has_evaluation_anchor:
         print("PR must reference EVALUATION (acceptance) anchor", file=sys.stderr)
         success = False
-    if not PRIORITY_PATTERN.search(normalized_body):
+    if not has_priority_label:
         print(
-            "PR must include 'Priority Score: <number>' to reflect Acceptance Criteria prioritization",
+            "Priority Score must be provided as '<number> / <justification>' to reflect Acceptance Criteria prioritization",
+            file=sys.stderr,
+        )
+        success = False
+    elif not PRIORITY_PATTERN.search(normalized_body):
+        print(
+            "Priority Score must be provided as '<number> / <justification>' to reflect Acceptance Criteria prioritization",
             file=sys.stderr,
         )
         success = False


### PR DESCRIPTION
## Summary
- add explicit regression tests for missing and unjustified Priority Score values in governance gate validation
- require Priority Score entries to include both the numeric value and trailing justification text when validating PR bodies

## Testing
- pytest workflow-cookbook/tests/test_check_governance_gate.py

------
https://chatgpt.com/codex/tasks/task_e_68f22fe2d9708321b553399877a21a74