### PR TITLE
Ensure Priority Score validation enforces justification

### DIFF
--- a/workflow-cookbook/tests/test_check_governance_gate.py
+++ b/workflow-cookbook/tests/test_check_governance_gate.py
@@ -135,7 +135,38 @@ Priority Score: 3
 
     assert validate_pr_body(body) is False
     captured = capsys.readouterr()
-    assert "Priority Score: <number>" in captured.err
+    assert (
+        "Priority Score must be provided as '<number> / <justification>' to reflect Acceptance Criteria prioritization"
+        in captured.err
+    )
+
+
+@pytest.mark.parametrize(
+    "priority_line",
+    [
+        "",
+        "Priority Score:",
+        "Priority Score: 4",
+        "Priority Score: 4 /",
+        "Priority Score: 4 /   ",
+    ],
+)
+def test_validate_pr_body_rejects_missing_priority_details(priority_line, capsys):
+    lines = [
+        "Intent: INT-4242",
+        "## EVALUATION",
+        "- [Acceptance Criteria](../EVALUATION.md#acceptance-criteria)",
+    ]
+    if priority_line:
+        lines.append(priority_line)
+    body = "\n".join(lines)
+
+    assert validate_pr_body(body) is False
+    captured = capsys.readouterr()
+    assert (
+        "Priority Score must be provided as '<number> / <justification>' to reflect Acceptance Criteria prioritization"
+        in captured.err
+    )
 
 
 def test_validate_pr_body_missing_intent(capsys):

--- a/workflow-cookbook/tools/ci/check_governance_gate.py
+++ b/workflow-cookbook/tools/ci/check_governance_gate.py
@@ -179,6 +179,7 @@ def validate_pr_body(body: str | None) -> bool:
     normalized_body = _normalize_markdown_emphasis(body or "")
     has_priority_label = bool(PRIORITY_LABEL_PATTERN.search(normalized_body))
     normalized_body = PRIORITY_LABEL_PATTERN.sub("Priority Score: ", normalized_body)
+    priority_match = PRIORITY_PATTERN.search(normalized_body) if has_priority_label else None
     success = True
 
     if not INTENT_PATTERN.search(normalized_body):
@@ -189,13 +190,7 @@ def validate_pr_body(body: str | None) -> bool:
     if not has_evaluation_heading or not has_evaluation_anchor:
         print("PR must reference EVALUATION (acceptance) anchor", file=sys.stderr)
         success = False
-    if not has_priority_label:
-        print(
-            "Priority Score must be provided as '<number> / <justification>' to reflect Acceptance Criteria prioritization",
-            file=sys.stderr,
-        )
-        success = False
-    elif not PRIORITY_PATTERN.search(normalized_body):
+    if not has_priority_label or priority_match is None:
         print(
             "Priority Score must be provided as '<number> / <justification>' to reflect Acceptance Criteria prioritization",
             file=sys.stderr,


### PR DESCRIPTION
## Summary
- add regression coverage for missing or incomplete Priority Score entries in governance gate tests
- tighten validate_pr_body to fail when Priority Score is absent or lacks justification

## Testing
- pytest workflow-cookbook/tests/test_check_governance_gate.py

------
https://chatgpt.com/codex/tasks/task_e_68f2611e10d883218430920c6d25e21b