### PR TITLE
Handle quoted empty front matter values

### DIFF
--- a/workflow-cookbook/tests/test_check_front_matter.py
+++ b/workflow-cookbook/tests/test_check_front_matter.py
@@ -46,6 +46,28 @@ def test_validate_markdown_front_matter_pass(repo_root: Path) -> None:
     assert validate_markdown_front_matter(repo_root) == {}
 
 
+@pytest.mark.parametrize("owner_value", ('""', "''"))
+def test_validate_markdown_front_matter_empty_owner(
+    repo_root: Path, owner_value: str
+) -> None:
+    _write_markdown(
+        repo_root / "README.md",
+        (
+            ("intent_id", "INT-555"),
+            ("owner", owner_value),
+            ("status", "active"),
+            ("last_reviewed_at", "2024-05-01"),
+            ("next_review_due", "2024-06-01"),
+        ),
+    )
+
+    missing = validate_markdown_front_matter(repo_root)
+
+    assert missing == {
+        repo_root / "README.md": [field for field in REQUIRED_FIELDS if field == "owner"]
+    }
+
+
 def test_validate_markdown_front_matter_missing_fields(repo_root: Path) -> None:
     _write_markdown(
         repo_root / "README.md",

--- a/workflow-cookbook/tools/ci/check_front_matter.py
+++ b/workflow-cookbook/tools/ci/check_front_matter.py
@@ -46,6 +46,10 @@ def _parse_fields(front_matter_lines: Iterable[str]) -> Dict[str, str]:
             if char == "#" and (index == 0 or value[index - 1].isspace()):
                 value = value[:index].rstrip()
                 break
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+            value = value[1:-1]
+        if value == "":
+            value = ""
         data[key.strip()] = value
     return data
 


### PR DESCRIPTION
## Summary
- add coverage for owner fields quoted as empty strings in front matter validation tests
- strip surrounding quotes from parsed values so quoted empty strings are treated as missing

## Testing
- pytest workflow-cookbook/tests/test_check_front_matter.py

------
https://chatgpt.com/codex/tasks/task_e_68f26d90e40c8321abb608f3edcc4977