### PR TITLE
Fix owner parsing with hashes in front matter

### DIFF
--- a/workflow-cookbook/tests/test_check_front_matter.py
+++ b/workflow-cookbook/tests/test_check_front_matter.py
@@ -68,6 +68,24 @@ def test_validate_markdown_front_matter_empty_owner(
     }
 
 
+@pytest.mark.parametrize("owner_value", ('"Team #1"', "'#platform-team'"))
+def test_validate_markdown_front_matter_owner_with_hash(
+    repo_root: Path, owner_value: str
+) -> None:
+    _write_markdown(
+        repo_root / "README.md",
+        (
+            ("intent_id", "INT-222"),
+            ("owner", owner_value),
+            ("status", "active"),
+            ("last_reviewed_at", "2024-07-01"),
+            ("next_review_due", "2024-08-01"),
+        ),
+    )
+
+    assert validate_markdown_front_matter(repo_root) == {}
+
+
 def test_validate_markdown_front_matter_missing_fields(repo_root: Path) -> None:
     _write_markdown(
         repo_root / "README.md",


### PR DESCRIPTION
## Summary
- add coverage for owner values that include hashes in the front matter tests
- ensure inline comments are stripped only outside quoted values when parsing front matter

## Testing
- pytest workflow-cookbook/tests/test_check_front_matter.py

------
https://chatgpt.com/codex/tasks/task_e_68f273dfafdc83219d587e150601ef89