### PR TITLE
Normalize governance gate pattern matching

### DIFF
--- a/workflow-cookbook/tests/test_check_governance_gate.py
+++ b/workflow-cookbook/tests/test_check_governance_gate.py
@@ -28,6 +28,11 @@ from tools.ci.check_governance_gate import (
             ["core/schema/model.yaml"],
         ),
         (
+            ["workflow-cookbook/core/schema/model.yaml"],
+            ["workflow-cookbook/core/schema/**"],
+            ["core/schema/model.yaml"],
+        ),
+        (
             ["workflow-cookbook/governance/policy.yaml"],
             ["/governance/**"],
             ["governance/policy.yaml"],

--- a/workflow-cookbook/tools/ci/check_governance_gate.py
+++ b/workflow-cookbook/tools/ci/check_governance_gate.py
@@ -174,7 +174,12 @@ def _normalize_changed_path(path: str) -> str:
 
 def find_forbidden_matches(paths: Iterable[str], patterns: Sequence[str]) -> List[str]:
     matches: List[str] = []
-    normalized_patterns = [pattern.lstrip("./") for pattern in patterns]
+    normalized_patterns: list[str] = []
+    for pattern in patterns:
+        normalized_pattern = _normalize_changed_path(pattern)
+        if not normalized_pattern:
+            continue
+        normalized_patterns.append(normalized_pattern)
     for path in paths:
         normalized_path = _normalize_changed_path(path)
         if not normalized_path:


### PR DESCRIPTION
## Summary
- add a regression test ensuring repository-prefixed paths trigger forbidden matches
- normalize forbidden path patterns before matching so governance gate catches subdirectory changes

## Testing
- pytest workflow-cookbook/tests/test_check_governance_gate.py

------
https://chatgpt.com/codex/tasks/task_e_68f27e3e607483218d73827e14f0a896