### PR TITLE
Handle inline list entries in governance gate

### DIFF
--- a/workflow-cookbook/tests/test_check_governance_gate.py
+++ b/workflow-cookbook/tests/test_check_governance_gate.py
@@ -330,6 +330,20 @@ self_modification:
         "auth/**",
     ]
 
+    inline_list_item_policy = tmp_path / "policy_inline_list_item.yaml"
+    inline_list_item_policy.write_text(
+        """
+self_modification:
+  forbidden_paths:
+    - ["/core/schema/**", "/auth/**"]
+"""
+    )
+
+    assert load_forbidden_patterns(inline_list_item_policy) == [
+        "core/schema/**",
+        "auth/**",
+    ]
+
 
 def test_collect_changed_paths_falls_back(monkeypatch):
     calls: list[list[str]] = []


### PR DESCRIPTION
## Summary
- add regression coverage for forbidden_paths entries that use inline list notation
- extend governance gate loader to normalize inline sequence values within list items

## Testing
- pytest workflow-cookbook/tests/test_check_governance_gate.py::test_load_forbidden_patterns

------
https://chatgpt.com/codex/tasks/task_e_68f27e49e4cc8321a214b4e01aec8a20