### PR TITLE
Fix governance gate wildcard matching at repo root

### DIFF
--- a/workflow-cookbook/tests/test_check_governance_gate.py
+++ b/workflow-cookbook/tests/test_check_governance_gate.py
@@ -34,6 +34,11 @@ from tools.ci.check_governance_gate import (
             ["core/schema/model.yaml"],
         ),
         (
+            ["schema/model.yaml"],
+            ["**/schema/**"],
+            ["schema/model.yaml"],
+        ),
+        (
             ["workflow-cookbook/governance/policy.yaml"],
             ["/governance/**"],
             ["governance/policy.yaml"],


### PR DESCRIPTION
## Summary
- add regression coverage for detecting schema wildcard violations at the repository root
- expand forbidden pattern matching to evaluate patterns with leading `**/` prefixes removed

## Testing
- pytest workflow-cookbook/tests/test_check_governance_gate.py -k find_forbidden_matches

------
https://chatgpt.com/codex/tasks/task_e_68f285752de483219e332cef85bcfaac