### PR TITLE
Handle inline comments in reflection fallback

### DIFF
--- a/.github/workflows/reflection.yml
+++ b/.github/workflows/reflection.yml
@@ -111,6 +111,28 @@ jobs:
               yaml = None
 
 
+          def _strip_inline_comment(value: str) -> str:
+              in_single = False
+              in_double = False
+              escaped = False
+              for index, char in enumerate(value):
+                  if escaped:
+                      escaped = False
+                      continue
+                  if char == "\\" and (in_single or in_double):
+                      escaped = True
+                      continue
+                  if char == "'" and not in_double:
+                      in_single = not in_single
+                      continue
+                  if char == '"' and not in_single:
+                      in_double = not in_double
+                      continue
+                  if char == "#" and not in_single and not in_double:
+                      return value[:index].rstrip()
+              return value.strip()
+
+
           def _fallback(content: str) -> str:
               report_indent = None
               quotes = ("'", '"')
@@ -127,6 +149,8 @@ jobs:
                           report_indent = None
                       if stripped.startswith("output:"):
                           value = stripped.split(":", 1)[1].strip()
+                          value = _strip_inline_comment(value)
+                          value = value.strip()
                           if len(value) >= 2 and value[0] == value[-1] and value[0] in quotes:
                               value = value[1:-1]
                           return value

--- a/workflow-cookbook/tests/test_workflows_reflection.py
+++ b/workflow-cookbook/tests/test_workflows_reflection.py
@@ -311,3 +311,27 @@ def test_reflection_workflow_commit_step_fallback_strips_quotes() -> None:
 
     assert isinstance(result, str)
     assert result == "reports/today.md"
+
+
+def test_reflection_workflow_commit_step_fallback_ignores_inline_comment() -> None:
+    run_block = _load_commit_run_block()
+    python_script = _extract_python_heredoc(run_block)
+
+    namespace: dict[str, object] = {"__name__": "__fallback_test__"}
+    exec(python_script, namespace)
+
+    fallback = namespace.get("_fallback")
+    assert isinstance(fallback, Callable)
+
+    fallback_fn: Callable[[str], str] = fallback
+    commented_content = textwrap.dedent(
+        """
+        report:
+          output: "reports/daily.md"  # note
+        """
+    ).strip()
+
+    result = fallback_fn(commented_content)
+
+    assert isinstance(result, str)
+    assert result == "reports/daily.md"


### PR DESCRIPTION
## Summary
- add coverage around the reflection fallback helper to ensure inline comments are ignored
- strip inline comments before unquoting report output when YAML parsing is unavailable

## Testing
- pytest workflow-cookbook/tests/test_workflows_reflection.py

------
https://chatgpt.com/codex/tasks/task_e_68f295284c088321a3640cccde4c9eea