### PR TITLE
Ensure reflection fallback ignores inline comments

### DIFF
--- a/.github/workflows/reflection.yml
+++ b/.github/workflows/reflection.yml
@@ -141,16 +141,17 @@ jobs:
                   if not stripped or stripped.startswith("#"):
                       continue
                   indent = len(raw_line) - len(raw_line.lstrip())
-                  if stripped.startswith("report:"):
+                  cleaned = _strip_inline_comment(stripped)
+                  if not cleaned:
+                      continue
+                  if cleaned.startswith("report:"):
                       report_indent = indent
                       continue
                   if report_indent is not None:
-                      if indent <= report_indent and ":" in stripped:
+                      if indent <= report_indent and ":" in cleaned:
                           report_indent = None
-                      if stripped.startswith("output:"):
-                          value = stripped.split(":", 1)[1].strip()
-                          value = _strip_inline_comment(value)
-                          value = value.strip()
+                      if cleaned.startswith("output:"):
+                          value = cleaned.split(":", 1)[1].strip()
                           if len(value) >= 2 and value[0] == value[-1] and value[0] in quotes:
                               value = value[1:-1]
                           return value

--- a/workflow-cookbook/tests/test_workflows_reflection.py
+++ b/workflow-cookbook/tests/test_workflows_reflection.py
@@ -335,3 +335,27 @@ def test_reflection_workflow_commit_step_fallback_ignores_inline_comment() -> No
 
     assert isinstance(result, str)
     assert result == "reports/daily.md"
+
+
+def test_reflection_workflow_commit_step_fallback_handles_commented_manifest_path() -> None:
+    run_block = _load_commit_run_block()
+    python_script = _extract_python_heredoc(run_block)
+
+    namespace: dict[str, object] = {"__name__": "__fallback_test__"}
+    exec(python_script, namespace)
+
+    fallback = namespace.get("_fallback")
+    assert isinstance(fallback, Callable)
+
+    fallback_fn: Callable[[str], str] = fallback
+    commented_content = textwrap.dedent(
+        """
+        report:
+          output: "reports/today.md"  # note
+        """
+    ).strip()
+
+    result = fallback_fn(commented_content)
+
+    assert isinstance(result, str)
+    assert result == "reports/today.md"


### PR DESCRIPTION
## Summary
- add a regression test covering commented report output paths in the reflection fallback
- strip inline comments before unquoting the report output in the fallback parser

## Testing
- pytest workflow-cookbook/tests/test_workflows_reflection.py -k fallback

------
https://chatgpt.com/codex/tasks/task_e_68f29a19877083219b881c946e093e4a