### PR TITLE
Fix fallback log parsing without PyYAML

### DIFF
--- a/workflow-cookbook/tests/test_analyze_script.py
+++ b/workflow-cookbook/tests/test_analyze_script.py
@@ -358,6 +358,24 @@ def test_load_results_reads_inline_comment_inline_logs_with_yaml_missing(
     assert statuses["custom::case"] == {"pass"}
 
 
+def test_load_results_reads_inline_logs_without_quotes_when_yaml_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    analyze = load_analyze_module()
+
+    _prepare_manifest_with_yaml_fallback(
+        analyze,
+        tmp_path,
+        monkeypatch,
+        "targets:\n  - name: unit\n    logs: [logs/custom.jsonl]\n",
+    )
+
+    tests, durs, fails, statuses = analyze.load_results()
+
+    assert (tests, durs, fails) == (["custom::case"], [12], [])
+    assert statuses["custom::case"] == {"pass"}
+
+
 def test_load_results_reads_inline_comment_block_logs_with_yaml_missing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- ensure fallback target log parsing normalizes values and handles manual list parsing
- add regression coverage for unquoted inline log lists when PyYAML is unavailable

## Testing
- pytest workflow-cookbook/tests/test_analyze_script.py -k yaml_missing


------
https://chatgpt.com/codex/tasks/task_e_68f29e137cd88321aecee24ecb9fca42