### PR TITLE
Ensure reflection workflow falls back to default report path

### DIFF
--- a/.github/workflows/reflection.yml
+++ b/.github/workflows/reflection.yml
@@ -111,6 +111,9 @@ jobs:
               yaml = None
 
 
+          DEFAULT_OUTPUT = "reports/today.md"
+
+
           def _strip_inline_comment(value: str) -> str:
               in_single = False
               in_double = False
@@ -154,8 +157,9 @@ jobs:
                           value = cleaned.split(":", 1)[1].strip()
                           if len(value) >= 2 and value[0] == value[-1] and value[0] in quotes:
                               value = value[1:-1]
-                          return value
-              raise SystemExit("report.output not found")
+                          if value:
+                              return value
+              return DEFAULT_OUTPUT
 
 
           def main() -> None:
@@ -164,7 +168,14 @@ jobs:
                   sys.stdout.write(_fallback(content))
                   return
               data = yaml.safe_load(content)
-              sys.stdout.write(data["report"]["output"])
+              if isinstance(data, dict):
+                  report_section = data.get("report")
+                  if isinstance(report_section, dict):
+                      output = report_section.get("output")
+                      if isinstance(output, str) and output.strip():
+                          sys.stdout.write(output.strip())
+                          return
+              sys.stdout.write(_fallback(content))
 
 
           if __name__ == "__main__":

--- a/workflow-cookbook/tests/test_workflows_reflection.py
+++ b/workflow-cookbook/tests/test_workflows_reflection.py
@@ -359,3 +359,31 @@ def test_reflection_workflow_commit_step_fallback_handles_commented_manifest_pat
 
     assert isinstance(result, str)
     assert result == "reports/today.md"
+
+
+def test_reflection_workflow_commit_step_defaults_to_today_when_output_missing(tmp_path: Path) -> None:
+    run_block = _load_commit_run_block()
+    python_script = _extract_python_heredoc(run_block)
+
+    temp_manifest = textwrap.dedent(
+        """
+        report:
+          format: markdown
+        """
+    ).strip()
+
+    manifest_path = tmp_path / "reflection.yaml"
+    manifest_path.write_text(temp_manifest, encoding="utf-8")
+
+    stdout = io.StringIO()
+    original_cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        with contextlib.redirect_stdout(stdout):
+            exec(python_script, {"__name__": "__main__"})
+    finally:
+        os.chdir(original_cwd)
+
+    derived_output = stdout.getvalue().strip()
+
+    assert derived_output == "reports/today.md"


### PR DESCRIPTION
## Summary
- add a workflow test that executes the Commit report script against a manifest without report.output
- update the Commit report Python snippet to default to reports/today.md when report.output is absent

## Testing
- pytest workflow-cookbook/tests/test_workflows_reflection.py

------
https://chatgpt.com/codex/tasks/task_e_68f29e1390908321b84d76afda7e0fe1