### PR TITLE
Remove unused fnmatch import from governance gate check

### DIFF
--- a/workflow-cookbook/tools/ci/check_governance_gate.py
+++ b/workflow-cookbook/tools/ci/check_governance_gate.py
@@ -6,7 +6,6 @@ import re
 import subprocess
 import sys
 import ast
-from fnmatch import fnmatch
 from pathlib import Path, PurePosixPath
 from typing import Iterable, List, Sequence
 


### PR DESCRIPTION
## Summary
- remove the unused fnmatch import from the governance gate check script

## Testing
- ruff check workflow-cookbook/tools/ci/check_governance_gate.py

------
https://chatgpt.com/codex/tasks/task_e_68f2a3977610832184076622d7b47dc8