### PR TITLE
Document governance policy template requirement

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,6 +4,7 @@
 最低限必要なのは次の通り：
 
 - `governance/policy.yaml`
+- `workflow-cookbook/governance/policy.yaml`
 - `workflow-cookbook/reflection.yaml`
 - `workflow-cookbook/scripts/analyze.py`
 - `.github/workflows/test.yml`
@@ -15,6 +16,8 @@
 - `docs/safety.md`
 - `logs/test.jsonl`（ダミー。最初の動作確認用）
 - `reports/.gitkeep`
+
+`workflow-cookbook/governance/policy.yaml` は CI が参照するテンプレートです。`governance/` 配下を整備する際は、このディレクトリごとコピーし、`governance/policy.yaml` を最新のポリシーで上書きしてください。
 
 ## 使い方
 1. push or PR → `test` が走り、`logs/test.jsonl` を生成

--- a/workflow-cookbook/tests/test_install_docs.py
+++ b/workflow-cookbook/tests/test_install_docs.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+
+def test_install_md_mentions_governance_policy():
+    install_md = Path(__file__).resolve().parents[2] / "INSTALL.md"
+    content = install_md.read_text(encoding="utf-8")
+
+    assert "workflow-cookbook/governance/policy.yaml" in content


### PR DESCRIPTION
## Summary
- add a regression test ensuring INSTALL.md lists the workflow governance policy template
- document copying workflow-cookbook/governance/policy.yaml in the installation checklist

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f2a5f1a358832195c4b2eff027cc68