### PR TITLE
Add README layout test and update repository paths

### DIFF
--- a/workflow-cookbook/.github/PULL_REQUEST_TEMPLATE.md
+++ b/workflow-cookbook/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,4 +32,5 @@
 - [ ] CHECKLISTS 該当項目完了
 - [ ] CHANGELOG 追記
 - 禁止パス遵守チェック（governance/policy.yaml）: <!-- 例: OK / 対象外 / 詳細 -->
-- Priority Score: <!-- 例: 5 / prioritization.yaml#phase1 -->
+Priority Score: <number> / <reference>
+<!-- 例: 5 / prioritization.yaml#phase1 -->

--- a/workflow-cookbook/README.md
+++ b/workflow-cookbook/README.md
@@ -15,8 +15,8 @@ canary rules.
 <!-- LLM-BOOTSTRAP v1 -->
 読む順番:
 
-1. docs/birdseye/index.json  …… ノード一覧・隣接関係（軽量）
-2. docs/birdseye/caps/`<path>`.json …… 必要ノードだけ point read（個別カプセル）
+1. `workflow-cookbook/docs/birdseye/index.json` …… ノード一覧・隣接関係（軽量）
+2. `workflow-cookbook/docs/birdseye/caps/<path>.json` …… 必要ノードだけ point read（個別カプセル）
 
 フォーカス手順:
 
@@ -37,18 +37,28 @@ canary rules.
 3. 実行手順は `RUNBOOK.md`、評価基準は `EVALUATION.md` に記述し、
    以下で Birdseye の最小読込とタスク分割の前提を共有
 
-    - [`GUARDRAILS.md`](GUARDRAILS.md) …… 行動指針と Birdseye の `deps_out`
+    - [`GUARDRAILS.md`](GUARDRAILS.md) …… (`workflow-cookbook/GUARDRAILS.md`) 行動指針と Birdseye の `deps_out`
       と整合する最小読込ガードレールを確認
-    - [`tools/codemap/README.md`](tools/codemap/README.md) …… Birdseye カプセル
-      再生成前提と `codemap.update` の流れを把握
+    - [`tools/codemap/README.md`](tools/codemap/README.md) …… (`workflow-cookbook/tools/codemap/README.md`)
+      Birdseye カプセル再生成前提と `codemap.update` の流れを把握
     - [`tools/codemap/update.py`](tools/codemap/update.py) …… `python tools/codemap/update.py`
-      で `codemap.update` を実行し Birdseye カプセルを再生成する
-      （`GUARDRAILS.md` の[鮮度管理](GUARDRAILS.md#%E9%AE%AE%E5%BA%A6%E7%AE%A1%E7%90%86staleness-handling)参照）
-    - [`HUB.codex.md`](HUB.codex.md) …… 仕様集約とタスク分割ハブを整備し、Birdseye カプセルの依存関係を維持
-    - [`docs/IN-20250115-001.md`](docs/IN-20250115-001.md) …… インシデントログを参照し
+      (`workflow-cookbook/tools/codemap/update.py`) で `codemap.update` を実行し Birdseye カプセルを再生成する
+      （`workflow-cookbook/GUARDRAILS.md` の[鮮度管理](GUARDRAILS.md#%E9%AE%AE%E5%BA%A6%E7%AE%A1%E7%90%86staleness-handling)参照）
+    - [`HUB.codex.md`](HUB.codex.md) …… (`workflow-cookbook/HUB.codex.md`) 仕様集約とタスク分割ハブを整備し、Birdseye カプセルの依存関係を維持
+    - [`docs/IN-20250115-001.md`](docs/IN-20250115-001.md) …… (`workflow-cookbook/docs/IN-20250115-001.md`)
+      インシデントログを参照し
       Birdseye カプセル要約で指示される `deps_out` を照合
-4. タスクごとに `TASK.codex.md` を複製して内容を埋め、エージェントに渡す
-5. リリースは `CHECKLISTS.md` をなぞり、差分は `CHANGELOG.md` に追記
+4. タスクごとに `workflow-cookbook/TASK.codex.md` を複製して内容を埋め、エージェントに渡す
+5. リリースは `workflow-cookbook/CHECKLISTS.md` をなぞり、差分は `workflow-cookbook/CHANGELOG.md` に追記
+
+## Repository structure
+
+- `workflow-cookbook/docs/` …… Birdseye カプセルや仕様補助ドキュメントを格納
+- `workflow-cookbook/governance/` …… ポリシーとガードレール定義を配置
+- `workflow-cookbook/logs/` …… インシデントやメトリクスの JSONL ログを保管
+- `workflow-cookbook/reports/` …… 日次レポートや評価結果を出力
+- `workflow-cookbook/scripts/` …… 自動化スクリプトとユーティリティを配置
+- `workflow-cookbook/tools/` …… Codemap などの補助ツールを格納
 
 <!-- markdownlint-disable MD013 -->
 ![lint](https://github.com/RNA4219/workflow-cookbook/actions/workflows/markdown.yml/badge.svg)

--- a/workflow-cookbook/tests/test_readme_layout.py
+++ b/workflow-cookbook/tests/test_readme_layout.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_readme_guides_repository_layout() -> None:
+    project_root = Path(__file__).resolve().parents[1]
+    readme = project_root / "README.md"
+
+    content = readme.read_text(encoding="utf-8")
+
+    assert "## Repository structure" in content, "README.md に Repository structure セクションを追加してください"
+
+    for relative_path in (
+        "workflow-cookbook/logs",
+        "workflow-cookbook/reports",
+        "workflow-cookbook/scripts",
+    ):
+        assert (
+            relative_path in content
+        ), f"README.md は {relative_path} のように正しい相対パスを案内する必要があります"


### PR DESCRIPTION
## Summary
- add a layout regression test for README to ensure repository paths are documented
- refresh README instructions to point to workflow-cookbook directories and add a Repository structure section
- align the PR template Priority Score placeholder with governance expectations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f2aeced21083219c0798fa5aaabb6b