### PR TITLE
docs: HUB.codex.md に YAML 出力例を追加し TASKS 対応表を追加

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -22,6 +22,18 @@
    - ファイル名は `TASK.<slug>-YYYY-MM-DD.md`。`<slug>` は英小文字ハイフン区切りで要約を表す。
    - Seed はドラフトからアクティブまでの状態を `status` で管理し、完了時は関連 PR/コミットリンクを追記する。
 
+## HUB 出力キーとの対応表（固定）
+
+| HUB 出力キー | Task Seed 転記先（`docs/TASKS.md` 須項目） | 転記ルール |
+| --- | --- | --- |
+| `task_id` | 識別情報 `task_id` | 日付ベース連番をそのまま記載 |
+| `source` | Notes（出典） | `orchestration/...#Phase...` 形式の参照を原文維持で記録 |
+| `objective` | Objective | 1文で転記（意図は変えない） |
+| `requirements` | Requirements | `behavior` / `constraints` / 受入基準へ展開 |
+| `commands` | Local Commands / Commands | 検証コマンドを順序維持で列挙 |
+| `dependencies` | Plan（着手条件） | 依存 Task ID を着手前提として明記 |
+| `status` | メタデータ `status` | `draft|active|...|done` の許容値に正規化 |
+
 ## 検証ログ
 - Seed 作成・更新時は以下を確認し、検証結果を Notes/Tests セクションへ残す。
   - メタデータがテンプレート順で埋まっているか。

--- a/workflow-cookbook/HUB.codex.md
+++ b/workflow-cookbook/HUB.codex.md
@@ -137,7 +137,7 @@ planned → active → in_progress → reviewing → done
 in_progress → blocked → in_progress（解除後に戻す）
 ```
 
-## 5. 出力例（擬似）
+## 5. 出力例（YAML）
 
 ```yaml
 - task_id: 20240401-01
@@ -153,9 +153,14 @@ in_progress → blocked → in_progress（解除後に戻す）
       - 既存API破壊禁止
   commands:
     - terraform plan -target=module.api_gateway
+    - terraform apply -target=module.api_gateway
   dependencies:
     - 20240331-ops-01
+  status: planned
 ```
+
+- `source` は `orchestration/<path>.md#Phase...` / `#Stage...` 形式で固定し、抽出元セクションへ追跡可能にする。
+- `status` は `Task Status & Blockers` の許容値のみ使用する。
 
 ## 6. 運用メモ
 


### PR DESCRIPTION
### Motivation
- Orchestration から自動生成する Task Seed の出力フォーマットを明確化し、必須キーを固定化するために YAML 例を追加する必要があった。
- HUB の出力と `docs/TASKS.md` の必須項目の転記ルールを一元化して自動化パイプラインの安定化を図る目的がある。

### Description
- `workflow-cookbook/HUB.codex.md` の「出力例」を「出力例（YAML）」へ変更し、例に必須キー `task_id`, `source`, `objective`, `requirements`, `commands`, `dependencies`, `status` を揃えた。 
- YAML 例に `terraform apply -target=module.api_gateway` と `status: planned` を追記し、`source` を `orchestration/<path>.md#Phase...` / `#Stage...` 形式で追跡可能にする旨を明文化した。 
- `docs/TASKS.md` に HUB 出力キーと Task Seed の須項目との対応表（転記先と転記ルール）を追加し、どのキーがどこへ転記されるかを固定化した。 
- 変更は小規模なドキュメント修正に限定し、既存の公開 API/CI 等には影響を与えない内容でコミット済み。 

### Testing
- 自動チェックとして `git -C /workspace/Day8 diff --check` を実行してエラーなし（成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6e1ce207c8321a2b737e05ba9d9c3)